### PR TITLE
[demo_week4] 캘린더 날짜별 달성률과 선택한 날짜에 따른 투두 출력 구현

### DIFF
--- a/app/src/main/java/com/gojol/notto/model/data/DateWithCountAndSelect.kt
+++ b/app/src/main/java/com/gojol/notto/model/data/DateWithCountAndSelect.kt
@@ -1,0 +1,7 @@
+package com.gojol.notto.model.data
+
+data class DateWithCountAndSelect(
+    val date: Int,
+    val count: Int,
+    val isSelected: Boolean
+)

--- a/app/src/main/java/com/gojol/notto/model/data/DateWithCountAndSelect.kt
+++ b/app/src/main/java/com/gojol/notto/model/data/DateWithCountAndSelect.kt
@@ -2,6 +2,6 @@ package com.gojol.notto.model.data
 
 data class DateWithCountAndSelect(
     val date: Int,
-    val count: Int,
+    val successLevel: Int,
     val isSelected: Boolean
 )

--- a/app/src/main/java/com/gojol/notto/model/database/todolabel/TodoLabelDao.kt
+++ b/app/src/main/java/com/gojol/notto/model/database/todolabel/TodoLabelDao.kt
@@ -38,6 +38,10 @@ interface TodoLabelDao {
     @Query("SELECT * FROM Label")
     suspend fun getAllLabel(): List<Label>
 
+    @Transaction
+    @Query("SELECT * FROM DailyTodo")
+    suspend fun getAllDailyTodo(): List<DailyTodo>
+
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertTodo(todo: Todo)
 

--- a/app/src/main/java/com/gojol/notto/model/datasource/todo/FakeTodoLabelRepository.kt
+++ b/app/src/main/java/com/gojol/notto/model/datasource/todo/FakeTodoLabelRepository.kt
@@ -96,6 +96,10 @@ class FakeTodoLabelRepository : TodoLabelDataSource {
         return labels
     }
 
+    override suspend fun getAllDailyTodos(): List<DailyTodo> {
+        return dailyTodos
+    }
+
     override suspend fun insertTodo(todo: Todo) {
         todos.add(todo)
     }

--- a/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelDataSource.kt
+++ b/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelDataSource.kt
@@ -22,6 +22,8 @@ interface TodoLabelDataSource {
 
     suspend fun getAllLabel(): List<Label>
 
+    suspend fun getAllDailyTodos(): List<DailyTodo>
+
     suspend fun insertTodo(todo: Todo)
 
     suspend fun insertTodo(todo: Todo, label: Label)

--- a/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelLocalDataSource.kt
+++ b/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelLocalDataSource.kt
@@ -47,6 +47,10 @@ class TodoLabelLocalDataSource(private val todoLabelDao: TodoLabelDao) :
         return todoLabelDao.getAllTodo()
     }
 
+    override suspend fun getAllDailyTodos(): List<DailyTodo> {
+        return todoLabelDao.getAllDailyTodo()
+    }
+
     override suspend fun getAllLabel(): List<Label> {
         return todoLabelDao.getAllLabel()
     }

--- a/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelLocalDataSource.kt
+++ b/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelLocalDataSource.kt
@@ -1,6 +1,7 @@
 package com.gojol.notto.model.datasource.todo
 
 import com.gojol.notto.common.TodoState
+import com.gojol.notto.model.data.RepeatType
 import com.gojol.notto.model.data.TodoWithTodayDailyTodo
 import com.gojol.notto.model.database.label.Label
 import com.gojol.notto.model.database.todo.DailyTodo
@@ -10,6 +11,9 @@ import com.gojol.notto.model.database.todolabel.LabelWithTodo
 import com.gojol.notto.model.database.todolabel.TodoLabelCrossRef
 import com.gojol.notto.model.database.todolabel.TodoLabelDao
 import com.gojol.notto.model.database.todolabel.TodoWithLabel
+import com.gojol.notto.util.getDate
+import com.gojol.notto.util.getMonth
+import com.gojol.notto.util.toCalendar
 
 class TodoLabelLocalDataSource(private val todoLabelDao: TodoLabelDao) :
     TodoLabelDataSource {
@@ -23,19 +27,53 @@ class TodoLabelLocalDataSource(private val todoLabelDao: TodoLabelDao) :
     }
 
     override suspend fun getTodosWithTodayDailyTodos(selectedDate: String): List<TodoWithTodayDailyTodo> {
-        return todoLabelDao.getTodosWithDailyTodos().map { todoWithDailyTodo ->
+        return todoLabelDao.getTodosWithDailyTodos().mapNotNull { todoWithDailyTodo ->
             val todo = todoWithDailyTodo.todo
             val dailyTodos = todoWithDailyTodo.dailyTodos
 
             var todayDailyTodo =
                 dailyTodos.find { it.parentTodoId == todo.todoId && it.date == selectedDate }
 
+            // 생성일을 db에 추가해야 반복설정을 하지 않았을 때 반영가능
+            // 일단 반복시작일이 시작일이라고 가정
             if (todayDailyTodo == null) {
-                todayDailyTodo = DailyTodo(TodoState.NOTHING, todo.todoId, selectedDate)
+                val repeatedDate = when {
+                    selectedDate == todo.startDate -> {
+                        selectedDate
+                    }
+                    todo.isRepeated -> {
+                        val dateDiff = ((todo.startDate.toCalendar().timeInMillis -
+                                selectedDate.toCalendar().timeInMillis) / 1000 / (24 * 60 * 60))
+                            .toInt()
+                        val dateEqual = todo.startDate.toCalendar().getDate() ==
+                                selectedDate.toCalendar().getDate()
+                        val monthEqual = todo.startDate.toCalendar().getMonth() ==
+                                selectedDate.toCalendar().getMonth()
+
+                        if ((selectedDate.toInt() > todo.startDate.toInt()) &&
+                            ((todo.repeatType == RepeatType.DAY) ||
+                                    (todo.repeatType == RepeatType.WEEK && (dateDiff % 7 == 0)) ||
+                                    (todo.repeatType == RepeatType.MONTH && dateEqual) ||
+                                    (todo.repeatType == RepeatType.YEAR && dateEqual && monthEqual))
+                        ) {
+                            selectedDate
+                        } else {
+                            null
+                        }
+                    }
+                    else -> {
+                        null
+                    }
+                }
+
+                todayDailyTodo = repeatedDate?.let { DailyTodo(TodoState.NOTHING, todo.todoId, it) }
+            }
+
+            if (todayDailyTodo != null) {
                 todoLabelDao.insertDailyTodo(todayDailyTodo)
             }
 
-            TodoWithTodayDailyTodo(todo, todayDailyTodo)
+            todayDailyTodo?.let { TodoWithTodayDailyTodo(todo, it) }
         }
     }
 

--- a/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelLocalDataSource.kt
+++ b/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelLocalDataSource.kt
@@ -45,7 +45,7 @@ class TodoLabelLocalDataSource(private val todoLabelDao: TodoLabelDao) :
                     }
                     else -> {
                         // 반복설정을 하지 않고 투두를 생성한 경우 오늘의 Daily 추가
-                        if (selectedDate == Calendar.getInstance().toYearMonthDate()){
+                        if (selectedDate == Calendar.getInstance().toYearMonthDate()) {
                             selectedDate
                         } else {
                             null
@@ -65,6 +65,14 @@ class TodoLabelLocalDataSource(private val todoLabelDao: TodoLabelDao) :
     }
 
     private fun checkRepeatedWhenSelectedDate(todo: Todo, selectedDate: String): String? {
+        return if (isValidRepeatedTodo(todo, selectedDate)) {
+            selectedDate
+        } else {
+            null
+        }
+    }
+
+    private fun isValidRepeatedTodo(todo: Todo, selectedDate: String): Boolean {
         val dateEqual = todo.startDate.toCalendar().getDate() ==
                 selectedDate.toCalendar().getDate()
         val weekEqual = todo.startDate.toCalendar().getDayOfWeek() ==
@@ -72,16 +80,11 @@ class TodoLabelLocalDataSource(private val todoLabelDao: TodoLabelDao) :
         val monthEqual = todo.startDate.toCalendar().getMonth() ==
                 selectedDate.toCalendar().getMonth()
 
-        return if ((selectedDate.toInt() >= todo.startDate.toInt()) &&
-            ((todo.repeatType == RepeatType.DAY) ||
-                    (todo.repeatType == RepeatType.WEEK && weekEqual) ||
-                    (todo.repeatType == RepeatType.MONTH && dateEqual) ||
-                    (todo.repeatType == RepeatType.YEAR && dateEqual && monthEqual))
-        ) {
-            selectedDate
-        } else {
-            null
-        }
+        return (selectedDate.toInt() >= todo.startDate.toInt()) &&
+                ((todo.repeatType == RepeatType.DAY) ||
+                        (todo.repeatType == RepeatType.WEEK && weekEqual) ||
+                        (todo.repeatType == RepeatType.MONTH && dateEqual) ||
+                        (todo.repeatType == RepeatType.YEAR && dateEqual && monthEqual))
     }
 
     override suspend fun getLabelsWithTodos(): List<LabelWithTodo> {

--- a/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelRepository.kt
+++ b/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelRepository.kt
@@ -39,6 +39,10 @@ class TodoLabelRepository @Inject constructor(
         return localDataSource.getAllLabel()
     }
 
+    override suspend fun getAllDailyTodos(): List<DailyTodo> {
+        return localDataSource.getAllDailyTodos()
+    }
+
     override suspend fun insertTodo(todo: Todo) {
         localDataSource.insertTodo(todo)
     }

--- a/app/src/main/java/com/gojol/notto/ui/home/CalendarFragment.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/CalendarFragment.kt
@@ -78,7 +78,6 @@ class CalendarFragment : Fragment() {
     }
 
     private fun dayClickCallback(date: Int) {
-        calendarViewModel.setMonthlyAchievement()
         time?.let { time ->
             val year = (time / 100).toInt()
             val month = (time % 100).toInt()

--- a/app/src/main/java/com/gojol/notto/ui/home/CalendarFragment.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/CalendarFragment.kt
@@ -42,6 +42,7 @@ class CalendarFragment : Fragment() {
 
         initObserver()
         initRecyclerView()
+        initViewModelData()
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/gojol/notto/ui/home/CalendarFragment.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/CalendarFragment.kt
@@ -20,7 +20,7 @@ class CalendarFragment : Fragment() {
 
     private lateinit var binding: FragmentCalendarBinding
     private val calendarViewModel: CalendarViewModel by viewModels()
-    private val calendarDayAdapter = CalendarDayAdapter()
+    private val calendarDayAdapter = CalendarDayAdapter(::dayClickCallback)
     private var time: Long? = null
 
     override fun onCreateView(
@@ -73,5 +73,9 @@ class CalendarFragment : Fragment() {
                 addItemDecoration(GridSpacingDecoration(it, 7))
             }
         }
+    }
+
+    private fun dayClickCallback(date: Int){
+        calendarViewModel.setMonthlyAchievement(date)
     }
 }

--- a/app/src/main/java/com/gojol/notto/ui/home/CalendarFragment.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/CalendarFragment.kt
@@ -40,9 +40,14 @@ class CalendarFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        initViewModelData()
         initObserver()
         initRecyclerView()
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        initViewModelData()
     }
 
     private fun initViewModelData() {

--- a/app/src/main/java/com/gojol/notto/ui/home/CalendarFragment.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/CalendarFragment.kt
@@ -78,6 +78,22 @@ class CalendarFragment : Fragment() {
     }
 
     private fun dayClickCallback(date: Int) {
-        calendarViewModel.setMonthlyAchievement(date)
+        calendarViewModel.setMonthlyAchievement()
+        time?.let { time ->
+            val year = (time / 100).toInt()
+            val month = (time % 100).toInt()
+
+            callback?.let { it(year, month, date) }
+            selectedYear = year
+            selectedMonth = month
+            selectedDate = date
+        }
+    }
+
+    companion object {
+        var selectedYear: Int? = null
+        var selectedMonth: Int? = null
+        var selectedDate: Int? = null
+        var callback: ((Int, Int, Int) -> (Unit))? = null
     }
 }

--- a/app/src/main/java/com/gojol/notto/ui/home/CalendarFragment.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/CalendarFragment.kt
@@ -62,8 +62,8 @@ class CalendarFragment : Fragment() {
     }
 
     private fun initObserver() {
-        calendarViewModel.monthlyAchievement.observe(viewLifecycleOwner, {
-            calendarDayAdapter.submitList(it)
+        calendarViewModel.monthlyAchievement.observe(viewLifecycleOwner, { itemList ->
+            calendarDayAdapter.submitList(itemList)
         })
     }
 
@@ -73,10 +73,11 @@ class CalendarFragment : Fragment() {
             context?.resources?.displayMetrics?.widthPixels?.let {
                 addItemDecoration(GridSpacingDecoration(it, 7))
             }
+            itemAnimator = null
         }
     }
 
-    private fun dayClickCallback(date: Int){
+    private fun dayClickCallback(date: Int) {
         calendarViewModel.setMonthlyAchievement(date)
     }
 }

--- a/app/src/main/java/com/gojol/notto/ui/home/CalendarViewModel.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/CalendarViewModel.kt
@@ -74,7 +74,7 @@ class CalendarViewModel @Inject constructor(
         }
     }
 
-    fun setMonthlyAchievement(selectedDate: Int? = null) {
+    fun setMonthlyAchievement() {
         val today = Calendar.getInstance()
 
         _monthlyAchievement.value = _monthDateList.value?.map { date ->
@@ -102,11 +102,14 @@ class CalendarViewModel @Inject constructor(
                 successLevel = 0
             }
 
-            val select = if (_year == today.getYear() && _month == today.getMonth()) {
-                date == selectedDate ?: today.getDate()
-            } else {
-                date == selectedDate ?: 1
-            }
+            val select =
+                if (CalendarFragment.selectedYear == _year &&
+                    CalendarFragment.selectedMonth == _month
+                ) {
+                    date == CalendarFragment.selectedDate ?: 1
+                } else {
+                    date == 1
+                }
 
             DateWithCountAndSelect(
                 date,

--- a/app/src/main/java/com/gojol/notto/ui/home/CalendarViewModel.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/CalendarViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gojol.notto.common.TodoState
+import com.gojol.notto.model.data.DateWithCountAndSelect
 import com.gojol.notto.model.database.todo.DailyTodo
 import com.gojol.notto.model.datasource.todo.TodoLabelRepository
 import com.gojol.notto.util.getDate
@@ -27,8 +28,11 @@ class CalendarViewModel @Inject constructor(
     private var _monthDateList = MutableLiveData<List<Int>>()
     private val _monthlyDailyTodos = MutableLiveData<List<DailyTodo>>()
 
-    private val _monthlyAchievement = MutableLiveData<List<Pair<Int, Int>>>()
-    val monthlyAchievement: LiveData<List<Pair<Int, Int>>> = _monthlyAchievement
+    private val _monthlyAchievement = MutableLiveData<List<DateWithCountAndSelect>>()
+    val monthlyAchievement: LiveData<List<DateWithCountAndSelect>> = _monthlyAchievement
+
+    private val _selectedDate = MutableLiveData<Int>()
+    val selectedDate: LiveData<Int> = _selectedDate
 
     fun setMonthDate(year: Int, month: Int) {
         val monthStartDate = Calendar.getInstance().apply {
@@ -63,11 +67,14 @@ class CalendarViewModel @Inject constructor(
         }
     }
 
-    fun setMonthlyAchievement() {
+    fun setMonthlyAchievement(selectedDate: Int? = null) {
         _monthlyAchievement.value = _monthDateList.value?.map { date ->
-            date to (_monthlyDailyTodos.value
-                ?.filter { it.date.takeLast(2).toInt() == date }
-                ?.count { it.todoState == TodoState.SUCCESS } ?: 0)
+            DateWithCountAndSelect(
+                date,
+                _monthlyDailyTodos.value
+                    ?.filter { it.date.takeLast(2).toInt() == date }
+                    ?.count { it.todoState == TodoState.SUCCESS } ?: 0,
+                date == selectedDate ?: Calendar.getInstance().getDate())
         }
         Log.i("daily", _monthlyAchievement.value.toString())
     }

--- a/app/src/main/java/com/gojol/notto/ui/home/CalendarViewModel.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/CalendarViewModel.kt
@@ -56,7 +56,7 @@ class CalendarViewModel @Inject constructor(
         viewModelScope.launch {
             launch {
                 monthlyDailyTodos = repository.getAllDailyTodos().filter {
-                    it.date > monthStartDate && it.date < monthLastDate
+                    it.date in monthStartDate..monthLastDate
                 }
             }.join()
 

--- a/app/src/main/java/com/gojol/notto/ui/home/CalendarViewModel.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/CalendarViewModel.kt
@@ -76,7 +76,32 @@ class CalendarViewModel @Inject constructor(
 
     fun setMonthlyAchievement(selectedDate: Int? = null) {
         val today = Calendar.getInstance()
+
         _monthlyAchievement.value = _monthDateList.value?.map { date ->
+            val todayDailyTodos = _monthlyDailyTodos.value
+                ?.filter { it.date.takeLast(2).toInt() == date }
+
+            val successCount = todayDailyTodos?.count { it.todoState == TodoState.SUCCESS } ?: 0
+
+            val totalCount = todayDailyTodos?.size ?: 0
+
+            val successRate = if (totalCount == 0) {
+                0.toFloat()
+            } else {
+                successCount.toFloat() / totalCount.toFloat()
+            }
+
+            var successLevel = when {
+                successRate <= 0.25 -> 1
+                successRate <= 0.5 -> 2
+                successRate <= 0.75 -> 3
+                successRate < 1 -> 4
+                else -> 5
+            }
+            if (totalCount == 0 || successCount == 0) {
+                successLevel = 0
+            }
+
             val select = if (_year == today.getYear() && _month == today.getMonth()) {
                 date == selectedDate ?: today.getDate()
             } else {
@@ -85,9 +110,7 @@ class CalendarViewModel @Inject constructor(
 
             DateWithCountAndSelect(
                 date,
-                _monthlyDailyTodos.value
-                    ?.filter { it.date.takeLast(2).toInt() == date }
-                    ?.count { it.todoState == TodoState.SUCCESS } ?: 0,
+                successLevel,
                 select
             )
         }

--- a/app/src/main/java/com/gojol/notto/ui/home/CalendarViewModel.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/CalendarViewModel.kt
@@ -1,6 +1,5 @@
 package com.gojol.notto.ui.home
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -12,8 +11,6 @@ import com.gojol.notto.model.datasource.todo.TodoLabelRepository
 import com.gojol.notto.util.getDate
 import com.gojol.notto.util.getDayOfWeek
 import com.gojol.notto.util.getLastDayOfMonth
-import com.gojol.notto.util.getMonth
-import com.gojol.notto.util.getYear
 import com.gojol.notto.util.toYearMonthDate
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -25,95 +22,89 @@ class CalendarViewModel @Inject constructor(
     private val repository: TodoLabelRepository
 ) : ViewModel() {
 
-    private var _year = 0
-    private var _month = 0
-    private val _monthStartDate = MutableLiveData<String>()
-    private val _monthLastDate = MutableLiveData<String>()
-    private val _monthDateList = MutableLiveData<List<Int>>()
-    private val _monthlyDailyTodos = MutableLiveData<List<DailyTodo>>()
+    private var currentCalendarYear = 0
+    private var currentCalendarMonth = 0
+    private var monthStartDate: String = ""
+    private var monthLastDate: String = ""
+    private var monthDateList = emptyList<Int>()
+    private var monthlyDailyTodos = emptyList<DailyTodo>()
 
     private val _monthlyAchievement = MutableLiveData<List<DateWithCountAndSelect>>()
     val monthlyAchievement: LiveData<List<DateWithCountAndSelect>> = _monthlyAchievement
 
-    private val _selectedDate = MutableLiveData<Int>()
-    val selectedDate: LiveData<Int> = _selectedDate
-
     fun setMonthDate(year: Int, month: Int) {
-        _year = year
-        _month = month
+        currentCalendarYear = year
+        currentCalendarMonth = month
 
-        val monthStartDate = Calendar.getInstance().apply {
+        val startDate = Calendar.getInstance().apply {
             set(year, month, 1)
         }
-        _monthStartDate.value = monthStartDate.toYearMonthDate()
+        monthStartDate = startDate.toYearMonthDate()
 
-        val monthLastDate = Calendar.getInstance().apply {
-            set(year, month, monthStartDate.getLastDayOfMonth())
+        val lastDate = Calendar.getInstance().apply {
+            set(year, month, startDate.getLastDayOfMonth())
         }
-        _monthLastDate.value = monthLastDate.toYearMonthDate()
+        monthLastDate = lastDate.toYearMonthDate()
 
-        val dateList = (monthStartDate.getDate()..monthLastDate.getDate()).toList()
-        val dayOfWeek = monthStartDate.getDayOfWeek() - 1
+        val dateList = (startDate.getDate()..lastDate.getDate()).toList()
+        val dayOfWeek = startDate.getDayOfWeek() - 1
         val prefixDateList = (0 until dayOfWeek).map { 0 }
-        _monthDateList.value = prefixDateList + dateList
+        monthDateList = prefixDateList + dateList
     }
 
     fun setMonthlyDailyTodos() {
         viewModelScope.launch {
-            _monthStartDate.value?.let { startDate ->
-                _monthLastDate.value?.let { lastDate ->
-                    launch {
-                        _monthlyDailyTodos.value = repository.getAllDailyTodos().filter {
-                            it.date > startDate && it.date < lastDate
-                        }
-                    }.join()
-
-                    setMonthlyAchievement()
+            launch {
+                monthlyDailyTodos = repository.getAllDailyTodos().filter {
+                    it.date > monthStartDate && it.date < monthLastDate
                 }
-            }
+            }.join()
+
+            setMonthlyAchievement()
         }
     }
 
     fun setMonthlyAchievement() {
-        _monthlyAchievement.value = _monthDateList.value?.map { date ->
-            val todayDailyTodos = _monthlyDailyTodos.value
-                ?.filter { it.date.takeLast(2).toInt() == date }
+        _monthlyAchievement.value = monthDateList.map { date ->
+            val todayDailyTodos = monthlyDailyTodos
+                .filter { it.date.takeLast(2).toInt() == date }
 
-            val successCount = todayDailyTodos?.count { it.todoState == TodoState.SUCCESS } ?: 0
+            DateWithCountAndSelect(date, getSuccessLevel(todayDailyTodos), getSuccess(date))
+        }
+    }
 
-            val totalCount = todayDailyTodos?.size ?: 0
+    private fun getSuccessLevel(todayDailyTodos: List<DailyTodo>): Int {
+        val successCount = todayDailyTodos.count { it.todoState == TodoState.SUCCESS }
+        val totalCount = todayDailyTodos.size
 
-            val successRate = if (totalCount == 0) {
-                0.toFloat()
-            } else {
-                successCount.toFloat() / totalCount.toFloat()
-            }
+        val successRate = if (totalCount == 0) {
+            0.toFloat()
+        } else {
+            successCount.toFloat() / totalCount.toFloat()
+        }
 
-            var successLevel = when {
-                successRate <= 0.25 -> 1
-                successRate <= 0.5 -> 2
-                successRate <= 0.75 -> 3
-                successRate < 1 -> 4
-                else -> 5
-            }
-            if (totalCount == 0 || successCount == 0) {
-                successLevel = 0
-            }
+        var successLevel = when {
+            successRate <= 0.25 -> 1
+            successRate <= 0.5 -> 2
+            successRate <= 0.75 -> 3
+            successRate < 1 -> 4
+            else -> 5
+        }
 
-            val select =
-                if (CalendarFragment.selectedYear == _year &&
-                    CalendarFragment.selectedMonth == _month
-                ) {
-                    date == CalendarFragment.selectedDate ?: 1
-                } else {
-                    false
-                }
+        if (totalCount == 0 || successCount == 0) {
+            successLevel = 0
+        }
 
-            DateWithCountAndSelect(
-                date,
-                successLevel,
-                select
-            )
+        return successLevel
+    }
+
+    private fun getSuccess(date: Int): Boolean {
+        return if (CalendarFragment.selectedYear == currentCalendarYear &&
+            CalendarFragment.selectedMonth == currentCalendarMonth
+        ) {
+            date == CalendarFragment.selectedDate ?: 1
+        } else {
+            false
         }
     }
 }

--- a/app/src/main/java/com/gojol/notto/ui/home/CalendarViewModel.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/CalendarViewModel.kt
@@ -1,0 +1,74 @@
+package com.gojol.notto.ui.home
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.gojol.notto.common.TodoState
+import com.gojol.notto.model.database.todo.DailyTodo
+import com.gojol.notto.model.datasource.todo.TodoLabelRepository
+import com.gojol.notto.util.getDate
+import com.gojol.notto.util.getDayOfWeek
+import com.gojol.notto.util.getLastDayOfMonth
+import com.gojol.notto.util.toYearMonthDate
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import java.util.*
+import javax.inject.Inject
+
+@HiltViewModel
+class CalendarViewModel @Inject constructor(
+    private val repository: TodoLabelRepository
+) : ViewModel() {
+
+    private var _monthStartDate = MutableLiveData<String>()
+    private var _monthLastDate = MutableLiveData<String>()
+    private var _monthDateList = MutableLiveData<List<Int>>()
+    private val _monthlyDailyTodos = MutableLiveData<List<DailyTodo>>()
+
+    private val _monthlyAchievement = MutableLiveData<List<Pair<Int, Int>>>()
+    val monthlyAchievement: LiveData<List<Pair<Int, Int>>> = _monthlyAchievement
+
+    fun setMonthDate(year: Int, month: Int) {
+        val monthStartDate = Calendar.getInstance().apply {
+            set(year, month, 1)
+        }
+        _monthStartDate.value = monthStartDate.toYearMonthDate()
+
+        val monthLastDate = Calendar.getInstance().apply {
+            set(year, month, monthStartDate.getLastDayOfMonth())
+        }
+        _monthLastDate.value = monthLastDate.toYearMonthDate()
+
+        val dateList = (monthStartDate.getDate()..monthLastDate.getDate()).toList()
+        val dayOfWeek = monthStartDate.getDayOfWeek() - 1
+        val prefixDateList = (0 until dayOfWeek).map { 0 }
+        _monthDateList.value = prefixDateList + dateList
+    }
+
+    fun setMonthlyDailyTodos() {
+        viewModelScope.launch {
+            _monthStartDate.value?.let { startDate ->
+                _monthLastDate.value?.let { lastDate ->
+                    launch {
+                        _monthlyDailyTodos.value = repository.getAllDailyTodos().filter {
+                            it.date > startDate && it.date < lastDate
+                        }
+                    }.join()
+
+                    setMonthlyAchievement()
+                }
+            }
+        }
+    }
+
+    fun setMonthlyAchievement() {
+        _monthlyAchievement.value = _monthDateList.value?.map { date ->
+            date to (_monthlyDailyTodos.value
+                ?.filter { it.date.takeLast(2).toInt() == date }
+                ?.count { it.todoState == TodoState.SUCCESS } ?: 0)
+        }
+        Log.i("daily", _monthlyAchievement.value.toString())
+    }
+}

--- a/app/src/main/java/com/gojol/notto/ui/home/CalendarViewModel.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/CalendarViewModel.kt
@@ -91,6 +91,5 @@ class CalendarViewModel @Inject constructor(
                 select
             )
         }
-        Log.i("daily", _monthlyAchievement.value.toString())
     }
 }

--- a/app/src/main/java/com/gojol/notto/ui/home/CalendarViewModel.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/CalendarViewModel.kt
@@ -75,8 +75,6 @@ class CalendarViewModel @Inject constructor(
     }
 
     fun setMonthlyAchievement() {
-        val today = Calendar.getInstance()
-
         _monthlyAchievement.value = _monthDateList.value?.map { date ->
             val todayDailyTodos = _monthlyDailyTodos.value
                 ?.filter { it.date.takeLast(2).toInt() == date }
@@ -108,7 +106,7 @@ class CalendarViewModel @Inject constructor(
                 ) {
                     date == CalendarFragment.selectedDate ?: 1
                 } else {
-                    date == 1
+                    false
                 }
 
             DateWithCountAndSelect(

--- a/app/src/main/java/com/gojol/notto/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/HomeFragment.kt
@@ -103,9 +103,7 @@ class HomeFragment : Fragment() {
         binding.rvHome.apply {
             adapter = concatAdapter
             layoutManager = getLayoutManager(concatAdapter)
-            itemAnimator?.removeDuration = 0
-            itemAnimator?.addDuration = 0
-            itemAnimator?.changeDuration = 0
+            itemAnimator = null
         }
     }
 

--- a/app/src/main/java/com/gojol/notto/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/HomeFragment.kt
@@ -140,6 +140,7 @@ class HomeFragment : Fragment() {
 
     private fun todoTouchCallback(dailyTodo: DailyTodo) {
         homeViewModel.updateDailyTodo(dailyTodo)
+        calendarAdapter.refreshAdapter()
     }
 
     private fun todoEditButtonCallback(todo: Todo) {

--- a/app/src/main/java/com/gojol/notto/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/HomeFragment.kt
@@ -1,6 +1,8 @@
 package com.gojol.notto.ui.home
 
 import android.content.Intent
+import java.util.Calendar
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -24,6 +26,9 @@ import com.gojol.notto.ui.home.adapter.LabelWrapperAdapter
 import com.gojol.notto.ui.home.adapter.TodoAdapter
 import com.gojol.notto.ui.home.util.TodoItemTouchCallback
 import com.gojol.notto.ui.todo.TodoEditActivity
+import com.gojol.notto.util.getDate
+import com.gojol.notto.util.getMonth
+import com.gojol.notto.util.getYear
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -56,12 +61,30 @@ class HomeFragment : Fragment() {
         initRecyclerView()
         initObserver()
         initTodoListItemTouchListener()
+        initCalendar()
+    }
+
+    private fun initCalendar() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            val today = Calendar.getInstance()
+            CalendarFragment.selectedYear = today.getYear()
+            CalendarFragment.selectedMonth = today.getMonth()
+            CalendarFragment.selectedDate = today.getDate()
+        }
+
+        // TODO *인터페이스, sharedviewmodel, eventbus
+        CalendarFragment.callback = ::updateSelectedDate
+    }
+
+    private fun updateSelectedDate(year: Int, month: Int, date: Int) {
+        homeViewModel.updateDate(year, month, date)
     }
 
     override fun onResume() {
         super.onResume()
 
         initData()
+        homeViewModel.updateDate()
     }
 
     private fun initRecyclerView() {
@@ -98,6 +121,7 @@ class HomeFragment : Fragment() {
 
         homeViewModel.date.observe(viewLifecycleOwner, {
             calendarAdapter.setDate(it)
+            homeViewModel.setDummyData()
         })
 
         homeViewModel.isTodoCreateButtonClicked.observe(viewLifecycleOwner, {

--- a/app/src/main/java/com/gojol/notto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/HomeViewModel.kt
@@ -51,13 +51,14 @@ class HomeViewModel @Inject constructor(private val repository: TodoLabelReposit
                 .toList()
             _todoList.value =
                 _date.value?.let { repository.getTodosWithTodayDailyTodos(it.toYearMonthDate()) }
-            _date.value = Calendar.getInstance()
         }
     }
 
-    fun updateDate(year: Int, month: Int, day: Int) {
+    fun updateDate(year: Int? = null, month: Int? = null, day: Int? = null) {
         val calendar: Calendar = Calendar.getInstance()
-        calendar.set(year, month, day)
+        if (year != null && month != null && day != null) {
+            calendar.set(year, month, day)
+        }
 
         _date.value = calendar
     }

--- a/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarAdapter.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarAdapter.kt
@@ -1,5 +1,7 @@
 package com.gojol.notto.ui.home.adapter
 
+import android.annotation.SuppressLint
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View.MeasureSpec
 import android.view.ViewGroup
@@ -34,6 +36,14 @@ class CalendarAdapter(private val requireActivity: FragmentActivity) :
 
     fun setDate(newDate: Calendar) {
         date = newDate
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun refreshAdapter() {
+//        TODO 애니메이션 문제 해결 필요
+//        notifyItemRemoved(0)
+//        notifyItemInserted(0)
+        notifyDataSetChanged()
     }
 
     class CustomCalendarViewHolder(private val binding: ItemCalendarBinding) :

--- a/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarAdapter.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarAdapter.kt
@@ -1,5 +1,6 @@
 package com.gojol.notto.ui.home.adapter
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View.MeasureSpec
 import android.view.ViewGroup
@@ -9,7 +10,10 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
 import com.gojol.notto.common.AdapterViewType
 import com.gojol.notto.databinding.ItemCalendarBinding
+import com.gojol.notto.ui.home.CalendarFragment
 import com.gojol.notto.util.getMonth
+import com.gojol.notto.util.getYear
+import com.gojol.notto.util.toYearMonthDate
 import java.util.Calendar
 
 class CalendarAdapter(private val requireActivity: FragmentActivity) :
@@ -52,10 +56,15 @@ class CalendarAdapter(private val requireActivity: FragmentActivity) :
         fun bind(today: Calendar, date: Calendar) {
             binding.date = date
 
-            val movePosition = date.getMonth() - today.getMonth()
+            val movePosition =
+                date.getMonth() - today.getMonth() + (date.getYear() - today.getYear()) * 12
+
             val calendarViewPagerAdapter = CalendarViewPagerAdapter(requireActivity)
             binding.vpCalendar.adapter = calendarViewPagerAdapter
-            binding.vpCalendar.setCurrentItem(calendarViewPagerAdapter.firstFragmentPosition + movePosition, false)
+            binding.vpCalendar.setCurrentItem(
+                calendarViewPagerAdapter.firstFragmentPosition + movePosition,
+                false
+            )
             setViewPagerDynamicHeight()
 
             binding.executePendingBindings()

--- a/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarAdapter.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarAdapter.kt
@@ -49,13 +49,10 @@ class CalendarAdapter(private val requireActivity: FragmentActivity) :
         private val requireActivity: FragmentActivity
     ) : RecyclerView.ViewHolder(binding.root) {
 
-        init {
+        fun bind(date: Calendar) {
             val calendarViewPagerAdapter = CalendarViewPagerAdapter(requireActivity)
             binding.vpCalendar.adapter = calendarViewPagerAdapter
             binding.vpCalendar.setCurrentItem(calendarViewPagerAdapter.firstFragmentPosition, false)
-        }
-
-        fun bind(date: Calendar) {
             binding.date = date
             setViewPagerDynamicHeight()
             binding.executePendingBindings()

--- a/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarAdapter.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarAdapter.kt
@@ -1,7 +1,5 @@
 package com.gojol.notto.ui.home.adapter
 
-import android.annotation.SuppressLint
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View.MeasureSpec
 import android.view.ViewGroup
@@ -11,12 +9,14 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
 import com.gojol.notto.common.AdapterViewType
 import com.gojol.notto.databinding.ItemCalendarBinding
+import com.gojol.notto.util.getMonth
 import java.util.Calendar
 
 class CalendarAdapter(private val requireActivity: FragmentActivity) :
     RecyclerView.Adapter<CalendarAdapter.CustomCalendarViewHolder>() {
 
-    private var date: Calendar = Calendar.getInstance()
+    private val today = Calendar.getInstance()
+    private var date = today
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CustomCalendarViewHolder {
         return CustomCalendarViewHolder(
@@ -26,7 +26,7 @@ class CalendarAdapter(private val requireActivity: FragmentActivity) :
     }
 
     override fun onBindViewHolder(holder: CustomCalendarViewHolder, position: Int) {
-        holder.bind(date)
+        holder.bind(today, date)
     }
 
     override fun getItemCount(): Int = 1
@@ -37,9 +37,9 @@ class CalendarAdapter(private val requireActivity: FragmentActivity) :
 
     fun setDate(newDate: Calendar) {
         date = newDate
+        notifyItemChanged(0)
     }
 
-    @SuppressLint("NotifyDataSetChanged")
     fun refreshAdapter() {
         notifyItemChanged(0)
     }
@@ -49,12 +49,15 @@ class CalendarAdapter(private val requireActivity: FragmentActivity) :
         private val requireActivity: FragmentActivity
     ) : RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(date: Calendar) {
+        fun bind(today: Calendar, date: Calendar) {
+            binding.date = date
+
+            val movePosition = date.getMonth() - today.getMonth()
             val calendarViewPagerAdapter = CalendarViewPagerAdapter(requireActivity)
             binding.vpCalendar.adapter = calendarViewPagerAdapter
-            binding.vpCalendar.setCurrentItem(calendarViewPagerAdapter.firstFragmentPosition, false)
-            binding.date = date
+            binding.vpCalendar.setCurrentItem(calendarViewPagerAdapter.firstFragmentPosition + movePosition, false)
             setViewPagerDynamicHeight()
+
             binding.executePendingBindings()
         }
 

--- a/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarAdapter.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarAdapter.kt
@@ -20,12 +20,13 @@ class CalendarAdapter(private val requireActivity: FragmentActivity) :
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CustomCalendarViewHolder {
         return CustomCalendarViewHolder(
-            ItemCalendarBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+            ItemCalendarBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+            requireActivity
         )
     }
 
     override fun onBindViewHolder(holder: CustomCalendarViewHolder, position: Int) {
-        holder.bind(requireActivity, date)
+        holder.bind(date)
     }
 
     override fun getItemCount(): Int = 1
@@ -40,20 +41,22 @@ class CalendarAdapter(private val requireActivity: FragmentActivity) :
 
     @SuppressLint("NotifyDataSetChanged")
     fun refreshAdapter() {
-//        TODO 애니메이션 문제 해결 필요
-//        notifyItemRemoved(0)
-//        notifyItemInserted(0)
-        notifyDataSetChanged()
+        notifyItemChanged(0)
     }
 
-    class CustomCalendarViewHolder(private val binding: ItemCalendarBinding) :
-        RecyclerView.ViewHolder(binding.root) {
+    class CustomCalendarViewHolder(
+        private val binding: ItemCalendarBinding,
+        private val requireActivity: FragmentActivity
+    ) : RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(requireActivity: FragmentActivity, date: Calendar) {
-            binding.date = date
+        init {
             val calendarViewPagerAdapter = CalendarViewPagerAdapter(requireActivity)
             binding.vpCalendar.adapter = calendarViewPagerAdapter
             binding.vpCalendar.setCurrentItem(calendarViewPagerAdapter.firstFragmentPosition, false)
+        }
+
+        fun bind(date: Calendar) {
+            binding.date = date
             setViewPagerDynamicHeight()
             binding.executePendingBindings()
         }

--- a/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarAdapter.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarAdapter.kt
@@ -1,6 +1,5 @@
 package com.gojol.notto.ui.home.adapter
 
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View.MeasureSpec
 import android.view.ViewGroup
@@ -10,10 +9,8 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
 import com.gojol.notto.common.AdapterViewType
 import com.gojol.notto.databinding.ItemCalendarBinding
-import com.gojol.notto.ui.home.CalendarFragment
 import com.gojol.notto.util.getMonth
 import com.gojol.notto.util.getYear
-import com.gojol.notto.util.toYearMonthDate
 import java.util.Calendar
 
 class CalendarAdapter(private val requireActivity: FragmentActivity) :

--- a/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarDayAdapter.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarDayAdapter.kt
@@ -1,6 +1,7 @@
 package com.gojol.notto.ui.home.adapter
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DiffUtil
@@ -8,13 +9,15 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.gojol.notto.R
 import com.gojol.notto.databinding.ItemCalendarDayBinding
+import com.gojol.notto.model.data.DateWithCountAndSelect
 
-class CalendarDayAdapter :
-    ListAdapter<Pair<Int, Int>, CalendarDayAdapter.CalendarDayViewHolder>(CalendarDayDiff()) {
+class CalendarDayAdapter(private val dayClickCallback: (Int) -> (Unit)) :
+    ListAdapter<DateWithCountAndSelect, CalendarDayAdapter.CalendarDayViewHolder>(CalendarDayDiff()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CalendarDayViewHolder {
         return CalendarDayViewHolder(
-            ItemCalendarDayBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+            ItemCalendarDayBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+            dayClickCallback
         )
     }
 
@@ -22,27 +25,49 @@ class CalendarDayAdapter :
         holder.bind(getItem(position))
     }
 
-    class CalendarDayViewHolder(private val binding: ItemCalendarDayBinding) :
+    class CalendarDayViewHolder(
+        private val binding: ItemCalendarDayBinding,
+        private val dayClickCallback: (Int) -> (Unit)
+    ) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(item: Pair<Int, Int>) {
-            val date = item.first
-            val achievement = item.second
+        init {
+            binding.tvCalendarDay.setOnClickListener {
+                dayClickCallback(binding.tvCalendarDay.text.toString().toInt())
+            }
+        }
+
+        fun bind(item: DateWithCountAndSelect) {
+            val date = item.date
+            val achievement = item.count
+
             if (date != 0) {
                 binding.tvCalendarDay.text = date.toString()
                 binding.tvCalendarDay.backgroundTintList =
                     ContextCompat.getColorStateList(binding.root.context, R.color.yellow_deep)
                         ?.withAlpha(51 * achievement)
+
+                if (item.isSelected) {
+                    binding.underline.visibility = View.VISIBLE
+                } else {
+                    binding.underline.visibility = View.INVISIBLE
+                }
             }
         }
     }
 
-    class CalendarDayDiff : DiffUtil.ItemCallback<Pair<Int, Int>>() {
-        override fun areItemsTheSame(oldItem: Pair<Int, Int>, newItem: Pair<Int, Int>): Boolean {
-            return oldItem.first == newItem.first
+    class CalendarDayDiff : DiffUtil.ItemCallback<DateWithCountAndSelect>() {
+        override fun areItemsTheSame(
+            oldItem: DateWithCountAndSelect,
+            newItem: DateWithCountAndSelect
+        ): Boolean {
+            return oldItem.date == newItem.date
         }
 
-        override fun areContentsTheSame(oldItem: Pair<Int, Int>, newItem: Pair<Int, Int>): Boolean {
+        override fun areContentsTheSame(
+            oldItem: DateWithCountAndSelect,
+            newItem: DateWithCountAndSelect
+        ): Boolean {
             return oldItem == newItem
         }
     }

--- a/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarDayAdapter.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarDayAdapter.kt
@@ -39,7 +39,7 @@ class CalendarDayAdapter(private val dayClickCallback: (Int) -> (Unit)) :
 
         fun bind(item: DateWithCountAndSelect) {
             val date = item.date
-            val achievement = item.count
+            val achievement = item.successLevel
 
             if (date != 0) {
                 binding.tvCalendarDay.text = date.toString()

--- a/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarDayAdapter.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarDayAdapter.kt
@@ -28,8 +28,7 @@ class CalendarDayAdapter(private val dayClickCallback: (Int) -> (Unit)) :
     class CalendarDayViewHolder(
         private val binding: ItemCalendarDayBinding,
         private val dayClickCallback: (Int) -> (Unit)
-    ) :
-        RecyclerView.ViewHolder(binding.root) {
+    ) : RecyclerView.ViewHolder(binding.root) {
 
         init {
             binding.tvCalendarDay.setOnClickListener {

--- a/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarDayAdapter.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarDayAdapter.kt
@@ -2,13 +2,15 @@ package com.gojol.notto.ui.home.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.gojol.notto.R
 import com.gojol.notto.databinding.ItemCalendarDayBinding
 
 class CalendarDayAdapter :
-    ListAdapter<Int, CalendarDayAdapter.CalendarDayViewHolder>(CalendarDayDiff()) {
+    ListAdapter<Pair<Int, Int>, CalendarDayAdapter.CalendarDayViewHolder>(CalendarDayDiff()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CalendarDayViewHolder {
         return CalendarDayViewHolder(
@@ -23,19 +25,24 @@ class CalendarDayAdapter :
     class CalendarDayViewHolder(private val binding: ItemCalendarDayBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(item: Int) {
-            if (item != 0){
-                binding.tvCalendarDay.text = item.toString()
+        fun bind(item: Pair<Int, Int>) {
+            val date = item.first
+            val achievement = item.second
+            if (date != 0) {
+                binding.tvCalendarDay.text = date.toString()
+                binding.tvCalendarDay.backgroundTintList =
+                    ContextCompat.getColorStateList(binding.root.context, R.color.yellow_deep)
+                        ?.withAlpha(51 * achievement)
             }
         }
     }
 
-    class CalendarDayDiff : DiffUtil.ItemCallback<Int>() {
-        override fun areItemsTheSame(oldItem: Int, newItem: Int): Boolean {
-            return oldItem == newItem
+    class CalendarDayDiff : DiffUtil.ItemCallback<Pair<Int, Int>>() {
+        override fun areItemsTheSame(oldItem: Pair<Int, Int>, newItem: Pair<Int, Int>): Boolean {
+            return oldItem.first == newItem.first
         }
 
-        override fun areContentsTheSame(oldItem: Int, newItem: Int): Boolean {
+        override fun areContentsTheSame(oldItem: Pair<Int, Int>, newItem: Pair<Int, Int>): Boolean {
             return oldItem == newItem
         }
     }

--- a/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarViewPagerAdapter.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarViewPagerAdapter.kt
@@ -1,11 +1,9 @@
 package com.gojol.notto.ui.home.adapter
 
-import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
-import androidx.viewpager2.adapter.FragmentViewHolder
 import com.gojol.notto.ui.home.CalendarFragment
 import com.gojol.notto.ui.home.TIME
 import java.util.Calendar
@@ -39,5 +37,9 @@ class CalendarViewPagerAdapter(
 
         // yyyyMM Format
         return (today.getYear() * 100 + today.getMonth()).toLong()
+    }
+
+    override fun containsItem(itemId: Long): Boolean {
+        return itemId in 20000102L..20991230L
     }
 }

--- a/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarViewPagerAdapter.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarViewPagerAdapter.kt
@@ -1,9 +1,11 @@
 package com.gojol.notto.ui.home.adapter
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import androidx.viewpager2.adapter.FragmentViewHolder
 import com.gojol.notto.ui.home.CalendarFragment
 import com.gojol.notto.ui.home.TIME
 import java.util.Calendar

--- a/app/src/main/java/com/gojol/notto/util/Extensions.kt
+++ b/app/src/main/java/com/gojol/notto/util/Extensions.kt
@@ -90,3 +90,9 @@ fun String.get24Hour(): String {
 fun String.timeSplitFormatter(): List<String> {
     return this.split(":")
 }
+
+fun String.toCalendar(): Calendar {
+    val calendar = Calendar.getInstance()
+    calendar.set(this.slice(0..3).toInt(), this.slice(4..5).toInt(), this.slice(6..7).toInt())
+    return calendar
+}

--- a/app/src/main/java/com/gojol/notto/util/Extensions.kt
+++ b/app/src/main/java/com/gojol/notto/util/Extensions.kt
@@ -93,6 +93,6 @@ fun String.timeSplitFormatter(): List<String> {
 
 fun String.toCalendar(): Calendar {
     val calendar = Calendar.getInstance()
-    calendar.set(this.slice(0..3).toInt(), this.slice(4..5).toInt(), this.slice(6..7).toInt())
+    calendar.set(this.slice(0..3).toInt(), this.slice(4..5).toInt() - 1, this.slice(6..7).toInt())
     return calendar
 }

--- a/app/src/main/java/com/gojol/notto/util/Extensions.kt
+++ b/app/src/main/java/com/gojol/notto/util/Extensions.kt
@@ -9,8 +9,15 @@ fun Calendar.toYearMonth(): String {
     return "${this.get(Calendar.YEAR)}년 ${this.get(Calendar.MONTH) + 1}월"
 }
 
+//yyyyMMdd
 fun Calendar.toYearMonthDate(): String {
-    return "${this.get(Calendar.YEAR)}${this.get(Calendar.MONTH) + 1}${this.get(Calendar.DATE)}"
+    val month = this.get(Calendar.MONTH) + 1
+    val formatMonth = if (month.toString().length == 1) "0$month" else month.toString()
+
+    val date = this.get(Calendar.DATE)
+    val formatDate = if (date.toString().length == 1) "0$date" else date.toString()
+
+    return "${this.get(Calendar.YEAR)}${formatMonth}${formatDate}"
 }
 
 fun Calendar.getYear(): Int {

--- a/app/src/main/res/drawable/bg_calendar_day_circle.xml
+++ b/app/src/main/res/drawable/bg_calendar_day_circle.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/white" />
+    <size
+        android:width="40dp"
+        android:height="40dp" />
+</shape>

--- a/app/src/main/res/layout/fragment_calendar.xml
+++ b/app/src/main/res/layout/fragment_calendar.xml
@@ -16,7 +16,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/item_calendar.xml
+++ b/app/src/main/res/layout/item_calendar.xml
@@ -142,7 +142,7 @@
         <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/vp_calendar"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="200dp"
             android:layout_marginTop="@dimen/space_median"
             android:orientation="horizontal"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_calendar.xml
+++ b/app/src/main/res/layout/item_calendar.xml
@@ -142,7 +142,7 @@
         <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/vp_calendar"
             android:layout_width="0dp"
-            android:layout_height="200dp"
+            android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/space_median"
             android:orientation="horizontal"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_calendar_day.xml
+++ b/app/src/main/res/layout/item_calendar_day.xml
@@ -15,15 +15,27 @@
             android:id="@+id/tv_calendar_day"
             android:layout_width="@dimen/calendar_day_size"
             android:layout_height="@dimen/calendar_day_size"
+            android:background="@drawable/bg_calendar_day_circle"
             android:gravity="center"
             android:textColor="@color/black"
             android:textSize="@dimen/text_x_small"
-            android:background="@drawable/bg_calendar_day_circle"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="10" />
+
+        <View
+            android:id="@+id/underline"
+            android:layout_width="3dp"
+            android:layout_height="3dp"
+            android:layout_marginTop="-10dp"
+            android:background="@color/black"
+            android:visibility="invisible"
+            app:layout_constraintEnd_toEndOf="@id/tv_calendar_day"
+            app:layout_constraintStart_toStartOf="@id/tv_calendar_day"
+            app:layout_constraintTop_toBottomOf="@id/tv_calendar_day"
+            tools:visibility="visible" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_calendar_day.xml
+++ b/app/src/main/res/layout/item_calendar_day.xml
@@ -18,6 +18,7 @@
             android:gravity="center"
             android:textColor="@color/black"
             android:textSize="@dimen/text_x_small"
+            android:background="@drawable/bg_calendar_day_circle"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
# 기능 구현 내용
- [x] 선택한 날짜에 표시(날짜 아래) 추가
- [x] 선택한 날짜별로 투두 출력(반복 설정으로 필터링해서 해당되는 경우만 DailyTodo를 생성)
- [x] 투두 스와이프시 바로 캘린더에 반영

# 기능 구현 결과
[개선전]
year 투두의 경우에 처음 day로 설정했을 때는 선택한 날짜의 DailyTodo가 다 추가되게 되어있어서 반복 옵션을 year로 설정해도 day일때 봤던 날짜들의 daily 기록은 살아있는게 정상입니다!

https://user-images.githubusercontent.com/64943924/142159815-cb38e78a-a6a2-480b-81a0-56a0c40cc121.mp4

[개선후]

https://user-images.githubusercontent.com/64943924/142339038-8ef71088-1bf2-4c34-9fb4-d9a36d26a5f9.mp4


# Resolve
- #11 

# 버그
- 매달 1일은 달성처리가 안뜨는 문제  -> 해결
- 달력이 6주일때 하단이 클릭할때마다 보였다 안보이는 현상 -> 해결
--
- 깜박임 현상 -> 다음 pr에서 해결할 예정


# 미구현사항(추후 구현예정)
- 캘린더 여닫기(#10)
- 캘린더 좌우 스크롤 이외의 이동방식(#12)