### PR TITLE
[demo_week4] Todo 삭제 기능 구현

### DIFF
--- a/app/src/main/java/com/gojol/notto/common/Constants.kt
+++ b/app/src/main/java/com/gojol/notto/common/Constants.kt
@@ -1,3 +1,4 @@
 package com.gojol.notto.common
 
 const val DIALOG_LABEL_ITEM_KEY = "label"
+const val DELETE = "todoDelete"

--- a/app/src/main/java/com/gojol/notto/common/Enums.kt
+++ b/app/src/main/java/com/gojol/notto/common/Enums.kt
@@ -16,3 +16,7 @@ enum class TimeRepeatType(val time: String, val text: String) {
 enum class EditType(val text: String) {
     CREATE("라벨 추가"), UPDATE("라벨 수정")
 }
+
+enum class TodoDeleteType {
+    TODAY, TODAY_AND_FUTURE
+}

--- a/app/src/main/java/com/gojol/notto/model/database/todolabel/TodoLabelDao.kt
+++ b/app/src/main/java/com/gojol/notto/model/database/todolabel/TodoLabelDao.kt
@@ -38,9 +38,8 @@ interface TodoLabelDao {
     @Query("SELECT * FROM Label")
     suspend fun getAllLabel(): List<Label>
 
-    @Transaction
-    @Query("SELECT * FROM TODO WHERE todoId=:todoId")
-    suspend fun getTodosWithDailyTodosByTodoId(todoId: Int): TodoWithDailyTodo
+    @Query("SELECT * FROM DailyTodo WHERE parent_todo_id=:parentTodoId")
+    suspend fun getDailyTodosByParentTodoId(parentTodoId: Int): List<DailyTodo>
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertTodo(todo: Todo)
@@ -77,6 +76,9 @@ interface TodoLabelDao {
 
     @Delete
     suspend fun deleteDailyTodo(dailyTodo: DailyTodo)
+
+    @Query("DELETE FROM DailyTodo WHERE parent_todo_id=:todoId and date=:date")
+    suspend fun deleteDailyTodoByTodoIdAndDate(todoId: Int, date: String)
 
     @Delete
     suspend fun deleteKeyword(keyword: Keyword)

--- a/app/src/main/java/com/gojol/notto/model/database/todolabel/TodoLabelDao.kt
+++ b/app/src/main/java/com/gojol/notto/model/database/todolabel/TodoLabelDao.kt
@@ -38,6 +38,10 @@ interface TodoLabelDao {
     @Query("SELECT * FROM Label")
     suspend fun getAllLabel(): List<Label>
 
+    @Transaction
+    @Query("SELECT * FROM TODO WHERE todoId=:todoId")
+    suspend fun getTodosWithDailyTodosByTodoId(todoId: Int): TodoWithDailyTodo
+
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertTodo(todo: Todo)
 

--- a/app/src/main/java/com/gojol/notto/model/datasource/todo/FakeTodoLabelRepository.kt
+++ b/app/src/main/java/com/gojol/notto/model/datasource/todo/FakeTodoLabelRepository.kt
@@ -15,6 +15,8 @@ import com.gojol.notto.util.getDate
 import com.gojol.notto.util.getMonth
 import com.gojol.notto.util.getYear
 
+const val ERROR_MSG = "잘못된 호출입니다."
+
 class FakeTodoLabelRepository : TodoLabelDataSource {
 
     var todoId = 10
@@ -219,6 +221,14 @@ class FakeTodoLabelRepository : TodoLabelDataSource {
                     LabelWithTodo(labelsWithTodos[i].label, labelsWithTodos[i].todo - todo)
             }
         }
+    }
+
+    override suspend fun deleteTodayTodo(todoId: Int, selectedDate: String) {
+        throw Exception(ERROR_MSG)
+    }
+
+    override suspend fun deleteTodayAndFutureTodo(todoId: Int, selectedDate: String) {
+        throw Exception(ERROR_MSG)
     }
 
     override suspend fun deleteLabel(label: Label) {

--- a/app/src/main/java/com/gojol/notto/model/datasource/todo/FakeTodoLabelRepository.kt
+++ b/app/src/main/java/com/gojol/notto/model/datasource/todo/FakeTodoLabelRepository.kt
@@ -15,8 +15,6 @@ import com.gojol.notto.util.getDate
 import com.gojol.notto.util.getMonth
 import com.gojol.notto.util.getYear
 
-const val ERROR_MSG = "잘못된 호출입니다."
-
 class FakeTodoLabelRepository : TodoLabelDataSource {
 
     var todoId = 10
@@ -251,6 +249,7 @@ class FakeTodoLabelRepository : TodoLabelDataSource {
     }
 
     companion object {
+        private const val ERROR_MSG = "잘못된 호출입니다."
         private var INSTANCE: FakeTodoLabelRepository? = null
 
         fun getInstance(): FakeTodoLabelRepository =

--- a/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelDataSource.kt
+++ b/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelDataSource.kt
@@ -40,5 +40,9 @@ interface TodoLabelDataSource {
 
     suspend fun deleteTodo(todo: Todo)
 
+    suspend fun deleteTodayTodo(todoId: Int, selectedDate: String)
+
+    suspend fun deleteTodayAndFutureTodo(todoId: Int, selectedDate: String)
+
     suspend fun deleteLabel(label: Label)
 }

--- a/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelLocalDataSource.kt
+++ b/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelLocalDataSource.kt
@@ -100,23 +100,18 @@ class TodoLabelLocalDataSource(private val todoLabelDao: TodoLabelDao) :
     }
 
     override suspend fun deleteTodayTodo(todoId: Int, selectedDate: String) {
-        val todoWithDailyTodo = todoLabelDao.getTodosWithDailyTodosByTodoId(todoId)
-        val todayTodo = todoWithDailyTodo.dailyTodos.find { dailyTodo ->
-            dailyTodo.date == selectedDate
-        } ?: return
-
-        todoLabelDao.deleteDailyTodo(todayTodo)
+        todoLabelDao.deleteDailyTodoByTodoIdAndDate(todoId, selectedDate)
     }
 
     override suspend fun deleteTodayAndFutureTodo(todoId: Int, selectedDate: String) {
         val selectedDateToDate = selectedDate.getDate()
-        val todoWithDailyTodo = todoLabelDao.getTodosWithDailyTodosByTodoId(todoId)
-        val todayAndFutureTodo = todoWithDailyTodo.dailyTodos.filter { dailyTodo ->
-            dailyTodo.date.getDate()?.compareTo(selectedDateToDate) == 0 || dailyTodo.date.getDate()
-                ?.compareTo(selectedDateToDate) == 1
-        }
+        val todosWithDailyTodos = todoLabelDao.getDailyTodosByParentTodoId(todoId)
+            .filter { dailyTodo ->
+                dailyTodo.date.getDate()?.compareTo(selectedDateToDate) == 0 ||
+                        dailyTodo.date.getDate()?.compareTo(selectedDateToDate) == 1
+            }
 
-        todayAndFutureTodo.forEach { dailyTodo ->
+        todosWithDailyTodos.forEach { dailyTodo ->
             todoLabelDao.deleteDailyTodo(dailyTodo)
         }
     }

--- a/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelLocalDataSource.kt
+++ b/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelLocalDataSource.kt
@@ -1,6 +1,5 @@
 package com.gojol.notto.model.datasource.todo
 
-import java.util.Calendar
 import com.gojol.notto.common.TodoState
 import com.gojol.notto.model.data.RepeatType
 import com.gojol.notto.model.data.TodoWithTodayDailyTodo
@@ -17,7 +16,7 @@ import com.gojol.notto.util.getDayOfWeek
 import com.gojol.notto.util.getMonth
 import com.gojol.notto.util.toCalendar
 import com.gojol.notto.util.toYearMonthDate
-import com.gojol.notto.util.getDate
+import java.util.*
 
 class TodoLabelLocalDataSource(private val todoLabelDao: TodoLabelDao) :
     TodoLabelDataSource {
@@ -156,11 +155,9 @@ class TodoLabelLocalDataSource(private val todoLabelDao: TodoLabelDao) :
     }
 
     override suspend fun deleteTodayAndFutureTodo(todoId: Int, selectedDate: String) {
-        val selectedDateToDate = selectedDate.getDate()
         val todosWithDailyTodos = todoLabelDao.getDailyTodosByParentTodoId(todoId)
             .filter { dailyTodo ->
-                dailyTodo.date.getDate()?.compareTo(selectedDateToDate) == 0 ||
-                        dailyTodo.date.getDate()?.compareTo(selectedDateToDate) == 1
+                dailyTodo.date.toInt() >= selectedDate.toInt()
             }
 
         todosWithDailyTodos.forEach { dailyTodo ->

--- a/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelLocalDataSource.kt
+++ b/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelLocalDataSource.kt
@@ -155,14 +155,13 @@ class TodoLabelLocalDataSource(private val todoLabelDao: TodoLabelDao) :
     }
 
     override suspend fun deleteTodayAndFutureTodo(todoId: Int, selectedDate: String) {
-        val todosWithDailyTodos = todoLabelDao.getDailyTodosByParentTodoId(todoId)
+        todoLabelDao.getDailyTodosByParentTodoId(todoId)
             .filter { dailyTodo ->
                 dailyTodo.date.toInt() >= selectedDate.toInt()
             }
-
-        todosWithDailyTodos.forEach { dailyTodo ->
-            todoLabelDao.deleteDailyTodo(dailyTodo)
-        }
+            .forEach { dailyTodo ->
+                todoLabelDao.deleteDailyTodo(dailyTodo)
+            }
     }
 
     override suspend fun deleteLabel(label: Label) {

--- a/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelRepository.kt
+++ b/app/src/main/java/com/gojol/notto/model/datasource/todo/TodoLabelRepository.kt
@@ -75,6 +75,14 @@ class TodoLabelRepository @Inject constructor(
         localDataSource.deleteTodo(todo)
     }
 
+    override suspend fun deleteTodayTodo(todoId: Int, selectedDate: String) {
+        localDataSource.deleteTodayTodo(todoId, selectedDate)
+    }
+
+    override suspend fun deleteTodayAndFutureTodo(todoId: Int, selectedDate: String) {
+        localDataSource.deleteTodayAndFutureTodo(todoId, selectedDate)
+    }
+
     override suspend fun deleteLabel(label: Label) {
         localDataSource.deleteLabel(label)
     }

--- a/app/src/main/java/com/gojol/notto/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/HomeFragment.kt
@@ -130,7 +130,9 @@ class HomeFragment : Fragment() {
 
         homeViewModel.todoEditButtonClicked.observe(viewLifecycleOwner, {
             it.getContentIfNotHandled()?.let { todo ->
-                startTodoCreateActivity(todo)
+                homeViewModel.date.value?.let { date ->
+                    startTodoCreateActivity(todo, date)
+                }
             }
         })
     }
@@ -178,9 +180,10 @@ class HomeFragment : Fragment() {
         startActivity(intent)
     }
 
-    private fun startTodoCreateActivity(todo: Todo) {
+    private fun startTodoCreateActivity(todo: Todo, date: Calendar) {
         val intent = Intent(activity, TodoEditActivity::class.java)
         intent.putExtra("todo", todo)
+        intent.putExtra("date", date)
         startActivity(intent)
     }
 }

--- a/app/src/main/java/com/gojol/notto/ui/todo/TodoEditActivity.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/TodoEditActivity.kt
@@ -10,16 +10,14 @@ import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.os.bundleOf
 import androidx.databinding.DataBindingUtil
 import com.gojol.notto.R
 import com.gojol.notto.databinding.ActivityTodoEditBinding
 import com.gojol.notto.model.database.label.Label
-import com.gojol.notto.ui.todo.dialog.TodoAlarmPeriodDialog
-import com.gojol.notto.ui.todo.dialog.TodoDeletionDialog
-import com.gojol.notto.ui.todo.dialog.TodoRepeatTimeDialog
-import com.gojol.notto.ui.todo.dialog.TodoRepeatTypeDialog
-import com.gojol.notto.ui.todo.dialog.TodoSetTimeDialog
 import com.gojol.notto.model.database.todo.Todo
+import com.gojol.notto.ui.todo.dialog.DELETE
+import com.gojol.notto.ui.todo.dialog.DELETE_DATA
 import com.gojol.notto.ui.todo.dialog.REPEAT_TIME
 import com.gojol.notto.ui.todo.dialog.REPEAT_TIME_DATA
 import com.gojol.notto.ui.todo.dialog.REPEAT_TYPE
@@ -30,6 +28,11 @@ import com.gojol.notto.ui.todo.dialog.TIME_REPEAT
 import com.gojol.notto.ui.todo.dialog.TIME_REPEAT_DATA
 import com.gojol.notto.ui.todo.dialog.TIME_START
 import com.gojol.notto.ui.todo.dialog.TIME_START_DATE
+import com.gojol.notto.ui.todo.dialog.TodoAlarmPeriodDialog
+import com.gojol.notto.ui.todo.dialog.TodoDeletionDialog
+import com.gojol.notto.ui.todo.dialog.TodoRepeatTimeDialog
+import com.gojol.notto.ui.todo.dialog.TodoRepeatTypeDialog
+import com.gojol.notto.ui.todo.dialog.TodoSetTimeDialog
 import com.gojol.notto.util.EventObserver
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -87,7 +90,18 @@ class TodoEditActivity : AppCompatActivity() {
         binding.tbTodoEdit.setOnMenuItemClickListener {
             when (it.itemId) {
                 R.id.delete_todo -> {
-                    //TODO todo 삭제
+                    // TODO: 새로 생성하는 경우면 ??
+                    if (todoEditViewModel.isTodoEditing.value == true) {
+                        todoDeletionDialog.apply {
+                            arguments = bundleOf(
+                                Pair(
+                                    DELETE_DATA,
+                                    todoEditViewModel.existedTodo.value?.todoId
+                                )
+                            )
+                        }
+                        todoDeletionDialog.show(supportFragmentManager, DELETE)
+                    }
                     true
                 }
                 else -> false

--- a/app/src/main/java/com/gojol/notto/ui/todo/TodoEditActivity.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/TodoEditActivity.kt
@@ -12,10 +12,10 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import com.gojol.notto.R
+import com.gojol.notto.common.DELETE
 import com.gojol.notto.databinding.ActivityTodoEditBinding
 import com.gojol.notto.model.database.label.Label
 import com.gojol.notto.model.database.todo.Todo
-import com.gojol.notto.ui.todo.dialog.DELETE
 import com.gojol.notto.ui.todo.dialog.REPEAT_TIME
 import com.gojol.notto.ui.todo.dialog.REPEAT_TIME_DATA
 import com.gojol.notto.ui.todo.dialog.REPEAT_TYPE

--- a/app/src/main/java/com/gojol/notto/ui/todo/TodoEditActivity.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/TodoEditActivity.kt
@@ -33,6 +33,7 @@ import com.gojol.notto.ui.todo.dialog.TodoRepeatTypeDialog
 import com.gojol.notto.ui.todo.dialog.TodoSetTimeDialog
 import com.gojol.notto.util.EventObserver
 import dagger.hilt.android.AndroidEntryPoint
+import java.util.*
 
 @AndroidEntryPoint
 class TodoEditActivity : AppCompatActivity() {
@@ -85,7 +86,9 @@ class TodoEditActivity : AppCompatActivity() {
 
     private fun initIntentExtra() {
         val todo = intent.getSerializableExtra("todo") as Todo?
+        val date = intent.getSerializableExtra("date") as Calendar?
         todoEditViewModel.updateIsTodoEditing(todo)
+        todoEditViewModel.updateDate(date)
     }
 
     private fun initAppbar() {
@@ -129,7 +132,7 @@ class TodoEditActivity : AppCompatActivity() {
         todoEditViewModel.isDeletionExecuted.observe(this) { event ->
             event.getContentIfNotHandled()?.let {
                 if (it) {
-                    finish()
+                    // finish()
                     Toast.makeText(
                         this,
                         getString(R.string.todo_edit_delete_message),

--- a/app/src/main/java/com/gojol/notto/ui/todo/TodoEditActivity.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/TodoEditActivity.kt
@@ -64,6 +64,11 @@ class TodoEditActivity : AppCompatActivity() {
     }
 
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        hideKeyboardWhenOutsideTouched(ev)
+        return super.dispatchTouchEvent(ev)
+    }
+
+    private fun hideKeyboardWhenOutsideTouched(ev: MotionEvent) {
         val view = currentFocus
         if (view != null && (ev.action == MotionEvent.ACTION_UP || ev.action == MotionEvent.ACTION_MOVE) &&
             view is EditText && !view.javaClass.name.startsWith("android.webkit.")
@@ -76,7 +81,6 @@ class TodoEditActivity : AppCompatActivity() {
                 (this.getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager)
                     .hideSoftInputFromWindow(this.window.decorView.applicationWindowToken, 0)
         }
-        return super.dispatchTouchEvent(ev)
     }
 
     private fun initIntentExtra() {

--- a/app/src/main/java/com/gojol/notto/ui/todo/TodoEditActivity.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/TodoEditActivity.kt
@@ -10,14 +10,12 @@ import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.os.bundleOf
 import androidx.databinding.DataBindingUtil
 import com.gojol.notto.R
 import com.gojol.notto.databinding.ActivityTodoEditBinding
 import com.gojol.notto.model.database.label.Label
 import com.gojol.notto.model.database.todo.Todo
 import com.gojol.notto.ui.todo.dialog.DELETE
-import com.gojol.notto.ui.todo.dialog.DELETE_DATA
 import com.gojol.notto.ui.todo.dialog.REPEAT_TIME
 import com.gojol.notto.ui.todo.dialog.REPEAT_TIME_DATA
 import com.gojol.notto.ui.todo.dialog.REPEAT_TYPE
@@ -92,14 +90,8 @@ class TodoEditActivity : AppCompatActivity() {
                 R.id.delete_todo -> {
                     // TODO: 새로 생성하는 경우면 ??
                     if (todoEditViewModel.isTodoEditing.value == true) {
-                        todoDeletionDialog.apply {
-                            arguments = bundleOf(
-                                Pair(
-                                    DELETE_DATA,
-                                    todoEditViewModel.existedTodo.value?.todoId
-                                )
-                            )
-                        }
+                        TodoDeletionDialog.deleteTodoCallback =
+                            todoEditViewModel::updateTodoDeleteType
                         todoDeletionDialog.show(supportFragmentManager, DELETE)
                     }
                     true
@@ -125,6 +117,21 @@ class TodoEditActivity : AppCompatActivity() {
         todoEditViewModel.isCloseButtonCLicked.observe(this) { event ->
             event.getContentIfNotHandled()?.let {
                 finish()
+            }
+        }
+        todoEditViewModel.todoDeleteType.observe(this) {
+            todoEditViewModel.deleteTodo()
+        }
+        todoEditViewModel.isDeletionExecuted.observe(this) { event ->
+            event.getContentIfNotHandled()?.let {
+                if (it) {
+                    finish()
+                    Toast.makeText(
+                        this,
+                        getString(R.string.todo_edit_delete_message),
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
             }
         }
         todoEditViewModel.labelList.observe(this) {

--- a/app/src/main/java/com/gojol/notto/ui/todo/TodoEditViewModel.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/TodoEditViewModel.kt
@@ -40,6 +40,9 @@ class TodoEditViewModel @Inject constructor(private val repository: TodoLabelRep
     private val _existedTodo = MutableLiveData<Todo>()
     val existedTodo: LiveData<Todo> = _existedTodo
 
+    private val _date = MutableLiveData<Calendar>()
+    val date: LiveData<Calendar> = _date
+
     private val _todoDeleteType = MutableLiveData<TodoDeleteType>()
     val todoDeleteType: LiveData<TodoDeleteType> = _todoDeleteType
 
@@ -155,6 +158,11 @@ class TodoEditViewModel @Inject constructor(private val repository: TodoLabelRep
         } ?: run {
             _isTodoEditing.value = false
         }
+    }
+
+    fun updateDate(date: Calendar?) {
+        val selectedDate = date ?: return
+        _date.value = selectedDate
     }
 
     fun updateIsCloseButtonClicked() {
@@ -308,8 +316,8 @@ class TodoEditViewModel @Inject constructor(private val repository: TodoLabelRep
     fun deleteTodo() {
         val todoId = existedTodo.value?.todoId ?: return
         val deleteType = todoDeleteType.value ?: return
+        val selectedDate = date.value?.toYearMonthDate() ?: return
 
-        val selectedDate = Calendar.getInstance().toYearMonthDate()
         viewModelScope.launch {
             when(deleteType) {
                 TodoDeleteType.TODAY -> repository.deleteTodayTodo(todoId, selectedDate)

--- a/app/src/main/java/com/gojol/notto/ui/todo/dialog/TodoDeletionDialog.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/dialog/TodoDeletionDialog.kt
@@ -6,18 +6,23 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import com.gojol.notto.R
+import com.gojol.notto.common.TodoDeleteType
 import com.gojol.notto.databinding.DialogDeletionBinding
 import dagger.hilt.android.AndroidEntryPoint
 
-const val DELETE_DATA = "todoDeleteData"
 const val DELETE = "todoDelete"
 
 @AndroidEntryPoint
 class TodoDeletionDialog : TodoBaseDialogImpl() {
     private lateinit var contentBinding: DialogDeletionBinding
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        contentBinding = DataBindingUtil.inflate(inflater, R.layout.dialog_deletion, container, false)
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        contentBinding =
+            DataBindingUtil.inflate(inflater, R.layout.dialog_deletion, container, false)
         return super.onCreateView(inflater, container, savedInstanceState)
     }
 
@@ -25,17 +30,15 @@ class TodoDeletionDialog : TodoBaseDialogImpl() {
         super.onViewCreated(view, savedInstanceState)
         contentBinding.lifecycleOwner = viewLifecycleOwner
         contentBinding.viewmodel = viewModel
-        initEditingTodoId()
         binding.clDialogContent.addView(contentBinding.root)
-    }
-
-    private fun initEditingTodoId() {
-        val todoId = requireArguments().getInt(DELETE_DATA)
-        viewModel.setEditingTodoId(todoId)
     }
 
     override fun confirmClick() {
         super.confirmClick()
-        viewModel.deleteTodo()
+        deleteTodoCallback?.let { it(viewModel.todoDeleteType.value) }
+    }
+
+    companion object {
+        var deleteTodoCallback: ((TodoDeleteType?) -> Unit)? = null
     }
 }

--- a/app/src/main/java/com/gojol/notto/ui/todo/dialog/TodoDeletionDialog.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/dialog/TodoDeletionDialog.kt
@@ -9,6 +9,9 @@ import com.gojol.notto.R
 import com.gojol.notto.databinding.DialogDeletionBinding
 import dagger.hilt.android.AndroidEntryPoint
 
+const val DELETE_DATA = "todoDeleteData"
+const val DELETE = "todoDelete"
+
 @AndroidEntryPoint
 class TodoDeletionDialog : TodoBaseDialogImpl() {
     private lateinit var contentBinding: DialogDeletionBinding
@@ -20,6 +23,19 @@ class TodoDeletionDialog : TodoBaseDialogImpl() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        contentBinding.lifecycleOwner = viewLifecycleOwner
+        contentBinding.viewmodel = viewModel
+        initEditingTodoId()
         binding.clDialogContent.addView(contentBinding.root)
+    }
+
+    private fun initEditingTodoId() {
+        val todoId = requireArguments().getInt(DELETE_DATA)
+        viewModel.setEditingTodoId(todoId)
+    }
+
+    override fun confirmClick() {
+        super.confirmClick()
+        viewModel.deleteTodo()
     }
 }

--- a/app/src/main/java/com/gojol/notto/ui/todo/dialog/TodoDeletionDialog.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/dialog/TodoDeletionDialog.kt
@@ -10,8 +10,6 @@ import com.gojol.notto.common.TodoDeleteType
 import com.gojol.notto.databinding.DialogDeletionBinding
 import dagger.hilt.android.AndroidEntryPoint
 
-const val DELETE = "todoDelete"
-
 @AndroidEntryPoint
 class TodoDeletionDialog : TodoBaseDialogImpl() {
     private lateinit var contentBinding: DialogDeletionBinding

--- a/app/src/main/java/com/gojol/notto/ui/todo/dialog/util/TodoBaseDialogViewModel.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/dialog/util/TodoBaseDialogViewModel.kt
@@ -6,17 +6,11 @@ import androidx.lifecycle.ViewModel
 import com.gojol.notto.common.TimeRepeatType
 import com.gojol.notto.common.TodoDeleteType
 import com.gojol.notto.model.data.RepeatType
-import com.gojol.notto.model.datasource.todo.TodoLabelRepository
 import com.gojol.notto.util.TouchEvent
 import com.gojol.notto.util.getDate
-import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.*
-import javax.inject.Inject
 
-@HiltViewModel
-class TodoBaseDialogViewModel @Inject constructor(
-    private val repository: TodoLabelRepository
-) : ViewModel() {
+class TodoBaseDialogViewModel : ViewModel() {
 
     private val _isConfirmClicked = MutableLiveData<TouchEvent<Boolean>>()
     val isConfirmClicked: LiveData<TouchEvent<Boolean>> = _isConfirmClicked
@@ -38,9 +32,6 @@ class TodoBaseDialogViewModel @Inject constructor(
 
     private val _timeRepeat = MutableLiveData<TimeRepeatType>()
     val timeRepeat: LiveData<TimeRepeatType> = _timeRepeat
-
-    private val _editingTodoId = MutableLiveData<Int>()
-    val editingTodoId: LiveData<Int> = _editingTodoId
 
     private val _todoDeleteType = MutableLiveData<TodoDeleteType>()
     val todoDeleteType: LiveData<TodoDeleteType> = _todoDeleteType
@@ -77,15 +68,7 @@ class TodoBaseDialogViewModel @Inject constructor(
         _timeRepeat.value = time
     }
 
-    fun setEditingTodoId(todoId: Int) {
-        _editingTodoId.value = todoId
-    }
-
     fun setTodoDeleteType(type: TodoDeleteType) {
         _todoDeleteType.value = type
-    }
-
-    fun deleteTodo() {
-        // TODO: 어떤 타입인지 확인하여 delete 처리
     }
 }

--- a/app/src/main/java/com/gojol/notto/ui/todo/dialog/util/TodoBaseDialogViewModel.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/dialog/util/TodoBaseDialogViewModel.kt
@@ -4,12 +4,19 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.gojol.notto.common.TimeRepeatType
+import com.gojol.notto.common.TodoDeleteType
 import com.gojol.notto.model.data.RepeatType
+import com.gojol.notto.model.datasource.todo.TodoLabelRepository
 import com.gojol.notto.util.TouchEvent
 import com.gojol.notto.util.getDate
+import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.*
+import javax.inject.Inject
 
-class TodoBaseDialogViewModel : ViewModel() {
+@HiltViewModel
+class TodoBaseDialogViewModel @Inject constructor(
+    private val repository: TodoLabelRepository
+) : ViewModel() {
 
     private val _isConfirmClicked = MutableLiveData<TouchEvent<Boolean>>()
     val isConfirmClicked: LiveData<TouchEvent<Boolean>> = _isConfirmClicked
@@ -31,6 +38,12 @@ class TodoBaseDialogViewModel : ViewModel() {
 
     private val _timeRepeat = MutableLiveData<TimeRepeatType>()
     val timeRepeat: LiveData<TimeRepeatType> = _timeRepeat
+
+    private val _editingTodoId = MutableLiveData<Int>()
+    val editingTodoId: LiveData<Int> = _editingTodoId
+
+    private val _todoDeleteType = MutableLiveData<TodoDeleteType>()
+    val todoDeleteType: LiveData<TodoDeleteType> = _todoDeleteType
 
     fun onConfirmClick() {
         _isConfirmClicked.value = TouchEvent(true)
@@ -62,5 +75,17 @@ class TodoBaseDialogViewModel : ViewModel() {
 
     fun setTimeRepeat(time: TimeRepeatType) {
         _timeRepeat.value = time
+    }
+
+    fun setEditingTodoId(todoId: Int) {
+        _editingTodoId.value = todoId
+    }
+
+    fun setTodoDeleteType(type: TodoDeleteType) {
+        _todoDeleteType.value = type
+    }
+
+    fun deleteTodo() {
+        // TODO: 어떤 타입인지 확인하여 delete 처리
     }
 }

--- a/app/src/main/java/com/gojol/notto/util/Extensions.kt
+++ b/app/src/main/java/com/gojol/notto/util/Extensions.kt
@@ -10,7 +10,13 @@ fun Calendar.toYearMonth(): String {
 }
 
 fun Calendar.toYearMonthDate(): String {
-    return "${this.get(Calendar.YEAR)}${this.get(Calendar.MONTH) + 1}${this.get(Calendar.DATE)}"
+    val month = this.get(Calendar.MONTH) + 1
+    val formatMonth = if (month.toString().length == 1) "0$month" else month.toString()
+
+    val date = this.get(Calendar.DATE)
+    val formatDate = if (date.toString().length == 1) "0$date" else date.toString()
+
+    return "${this.get(Calendar.YEAR)}${formatMonth}${formatDate}"
 }
 
 fun Calendar.getYear(): Int {

--- a/app/src/main/res/layout/dialog_deletion.xml
+++ b/app/src/main/res/layout/dialog_deletion.xml
@@ -4,21 +4,21 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
+        <import type="com.gojol.notto.common.TodoDeleteType" />
+
         <variable
             name="viewmodel"
             type="com.gojol.notto.ui.todo.dialog.util.TodoBaseDialogViewModel" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+    <androidx.constraintlayout.widget.ConstraintLayout style="@style/edit_label_dialog_layout">
 
         <TextView
             android:id="@+id/tv_dialog_deletion_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/dialog_margin"
-            android:fontFamily="@font/font_nanumsquare"
             android:text="@string/dialog_deletion_title"
             android:textColor="@color/black"
             android:textSize="@dimen/text_large"
@@ -28,20 +28,41 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/tv_dialog_deletion_description"
+        <RadioGroup
+            android:id="@+id/rg_dialog_todo_delete"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/dialog_margin"
-            android:layout_marginEnd="@dimen/dialog_deletion_description_margin_end"
-            android:fontFamily="@font/font_nanumsquare"
-            android:lineSpacingExtra="@dimen/dialog_line_spacing"
-            android:text="@string/dialog_deletion_description"
-            android:textColor="@color/black"
+            android:layout_marginTop="@dimen/space_median"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="@+id/tv_dialog_deletion_title"
-            app:layout_constraintTop_toBottomOf="@+id/tv_dialog_deletion_title" />
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintStart_toStartOf="@id/tv_dialog_deletion_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_dialog_deletion_title">
+
+            <RadioButton
+                android:id="@+id/rb_dialog_todo_delete_only_today"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:buttonTint="@color/bg_radio_button_normal"
+                android:checked="@{viewmodel.todoDeleteType == TodoDeleteType.TODAY ? true : false}"
+                android:maxLines="1"
+                android:onClick="@{() -> viewmodel.setTodoDeleteType(TodoDeleteType.TODAY)}"
+                android:text="@string/dialog_todo_delete_only_today"
+                android:textColor="@color/black"
+                android:textStyle="bold" />
+
+            <RadioButton
+                android:id="@+id/rb_dialog_todo_delete_all"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:buttonTint="@color/bg_radio_button_normal"
+                android:checked="@{viewmodel.todoDeleteType == TodoDeleteType.TODAY_AND_FUTURE ? true : false}"
+                android:maxLines="1"
+                android:onClick="@{() -> viewmodel.setTodoDeleteType(TodoDeleteType.TODAY_AND_FUTURE)}"
+                android:text="@string/dialog_todo_delete_all"
+                android:textColor="@color/black"
+                android:textStyle="bold" />
+
+        </RadioGroup>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="todo_edit_label_select">라벨 선택</string>
     <string name="todo_edit_label_select_sentence">라벨을 선택하세요</string>
     <string name="todo_edit_button_disabled_message">부족한 항목을 채워주세요!</string>
+    <string name="todo_edit_delete_message">Not Todo가 삭제되었습니다.</string>
 
     <string name="dialog_deletion_title">Not Todo 삭제하기</string>
     <string name="dialog_deletion_description">삭제하면 다시 복구할 수 없습니다. \n정말 삭제하시겠습니까?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,8 @@
     <string name="dialog_repeat_type_everyweek">매주</string>
     <string name="dialog_repeat_type_everymonth">매월</string>
     <string name="dialog_repeat_type_everyyear">매년</string>
+    <string name="dialog_todo_delete_only_today">오늘만</string>
+    <string name="dialog_todo_delete_all">오늘 및 향후 Not Todo</string>
 
     <string name="calendar_sunday">일</string>
     <string name="calendar_monday">월</string>


### PR DESCRIPTION
# 기능 구현 내용
- [x] Todo 삭제 다이얼로그 레이아웃 수정
- [x] Todo 삭제 다이얼로그 기능 구현
- [x] Todo 삭제 기능 구현

# 기능 구현 결과

https://user-images.githubusercontent.com/55148494/142221687-59a74990-aba2-4eb4-ae0d-683f11e2d470.mp4


- 11/18~11/30 매일 Todo (11/19 제외)
![delete_todo_day_1](https://user-images.githubusercontent.com/55148494/142353907-17a5bbeb-59e1-4dd3-89c7-387b1a1ac8b8.PNG)

- 11/21부터 향후 투두 삭제
![delete_todo_day_2](https://user-images.githubusercontent.com/55148494/142353903-a2e604f9-fbdf-43ab-8885-1fdbb63ee15a.PNG)

- 11/18 오늘 투두만 삭제
![delete_todo_day_3](https://user-images.githubusercontent.com/55148494/142353900-327c4d72-804f-4ac8-a172-7e46954a133c.PNG)


# Resolve
- #13 

# 기타
현재는 삭제 후 투두 편집화면에 머물러있지만 나중에 DailyTodo 생성 로직이 완성되면 편집화면이 닫히도록 하면 될 것 같습니다!