### PR TITLE
[demo_week4] 라벨 간격 맞춤

### DIFF
--- a/app/src/main/res/drawable/ic_check.xml
+++ b/app/src/main/res/drawable/ic_check.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
+</vector>

--- a/app/src/main/res/layout/item_label.xml
+++ b/app/src/main/res/layout/item_label.xml
@@ -4,12 +4,15 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="viewModel"
             type="com.gojol.notto.ui.home.HomeViewModel" />
+
         <variable
             name="item"
             type="com.gojol.notto.model.database.label.Label" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -21,16 +24,21 @@
             style="@style/Widget.MaterialComponents.Chip.Choice"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="2dp"
             android:clickable="true"
             android:focusable="true"
             android:text="@{item.name}"
             android:textColor="@color/black"
             android:textSize="@dimen/text_x_small"
-            android:layout_marginHorizontal="2dp"
             android:textStyle="bold"
             app:chipBackgroundColor="@color/bg_chip_normal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
+            app:checkedIcon="@drawable/ic_check"
+            app:checkedIconTint="@color/black"
+            app:checkedIconEnabled="true"
             tools:checked="true"
             tools:text="@string/home_label_all" />
 

--- a/app/src/main/res/layout/item_label.xml
+++ b/app/src/main/res/layout/item_label.xml
@@ -29,7 +29,7 @@
             android:focusable="true"
             android:text="@{item.name}"
             android:textColor="@color/black"
-            android:textSize="@dimen/text_x_small"
+            android:textSize="@dimen/text_x_x_small"
             android:textStyle="bold"
             app:chipBackgroundColor="@color/bg_chip_normal"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,6 +2,7 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
+    <dimen name="text_x_x_small">14sp</dimen>
     <dimen name="text_x_small">16sp</dimen>
     <dimen name="text_small">18sp</dimen>
     <dimen name="text_median">20sp</dimen>


### PR DESCRIPTION
# 기능 구현 내용
- [x] 라벨에 칩아이콘을 추가해 간격 맞춤
- [x] 라벨 텍스트 사이즈 축소

# 기능 구현 결과

<img width=300 src=https://user-images.githubusercontent.com/39328846/142351460-3ab4b8a9-ca08-4ca0-849d-dad55a05d234.jpg>

# 기타
Chip의 크기가 너무 작아지면 선택하기 어려워지는 문제가 있어서 Chip이 차지하는 최소 너비가 정해져 있고 그 너비보다 작아지지 않도록 아이콘을 추가하는 것을 권장한다고 합니다!
