### PR TITLE
[demo_week4] 투두 편집 화면 디자인 리팩토링

### DIFF
--- a/app/src/main/java/com/gojol/notto/ui/todo/SelectedLabelAdapter.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/SelectedLabelAdapter.kt
@@ -5,17 +5,15 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.gojol.notto.databinding.ItemLabelBinding
+import com.gojol.notto.databinding.ItemEditTodoLabelBinding
 import com.gojol.notto.model.database.label.Label
 
 class SelectedLabelAdapter(private val labelCallback: (Label) -> (Unit)) :
-    ListAdapter<Label, SelectedLabelAdapter.SelectedLabelViewHolder>(
-        LabelDiffCallback()
-    ) {
+    ListAdapter<Label, SelectedLabelAdapter.SelectedLabelViewHolder>(LabelDiffCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SelectedLabelViewHolder {
         return SelectedLabelViewHolder(
-            ItemLabelBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+            ItemEditTodoLabelBinding.inflate(LayoutInflater.from(parent.context), parent, false),
             labelCallback
         )
     }
@@ -25,7 +23,7 @@ class SelectedLabelAdapter(private val labelCallback: (Label) -> (Unit)) :
     }
 
     class SelectedLabelViewHolder(
-        private val binding: ItemLabelBinding,
+        private val binding: ItemEditTodoLabelBinding,
         private val callback: (Label) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
 

--- a/app/src/main/res/drawable/ic_cancel.xml
+++ b/app/src/main/res/drawable/ic_cancel.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z"/>
+</vector>

--- a/app/src/main/res/layout/activity_edit_label.xml
+++ b/app/src/main/res/layout/activity_edit_label.xml
@@ -20,7 +20,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:title="@string/edit_label"
-            app:titleCentered="true"
             app:navigationIcon="@drawable/ic_close"
             app:menu="@menu/edit_label_toolbar_menu"
             style="@style/Theme.Notto.Toolbar.Primary" />

--- a/app/src/main/res/layout/activity_todo_edit.xml
+++ b/app/src/main/res/layout/activity_todo_edit.xml
@@ -8,6 +8,7 @@
         <variable
             name="viewmodel"
             type="com.gojol.notto.ui.todo.TodoEditViewModel" />
+
     </data>
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -91,7 +92,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@+id/btn_todo_edit_label"
                     app:layout_constraintTop_toTopOf="@+id/btn_todo_edit_label"
-                    tools:listitem="@layout/item_label" />
+                    tools:listitem="@layout/item_edit_todo_label" />
 
                 <!-- 반복 설정 -->
                 <ImageView

--- a/app/src/main/res/layout/activity_todo_edit.xml
+++ b/app/src/main/res/layout/activity_todo_edit.xml
@@ -11,37 +11,34 @@
 
     </data>
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <com.google.android.material.appbar.AppBarLayout
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/tb_todo_edit"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="?attr/actionBarSize"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:menu="@menu/todo_edit_top_app_bar"
+            app:navigationIcon="@drawable/ic_close"
+            app:navigationOnClickListener="@{() -> viewmodel.updateIsCloseButtonClicked()}"
+            app:title="@string/todo_edit_title"
+            style="@style/Theme.Notto.Toolbar.Primary" />
 
-            <com.google.android.material.appbar.MaterialToolbar
-                android:id="@+id/tb_todo_edit"
-                style="@style/Widget.MaterialComponents.Toolbar.Primary"
-                android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
-                android:background="@android:color/white"
-                app:menu="@menu/todo_edit_top_app_bar"
-                app:navigationIcon="@drawable/ic_close"
-                app:navigationOnClickListener="@{() -> viewmodel.updateIsCloseButtonClicked()}"
-                app:title="@string/todo_edit_title"
-                app:titleCentered="true"
-                app:titleTextColor="@color/black" />
-
-        </com.google.android.material.appbar.AppBarLayout>
-
-        <androidx.core.widget.NestedScrollView
+        <ScrollView
+            android:id="@+id/scrollView2"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior">
+            android:layout_height="0dp"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"
+            app:layout_constraintTop_toBottomOf="@+id/tb_todo_edit"
+            app:layout_constraintBottom_toBottomOf="parent">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 tools:context=".ui.todo.TodoEditActivity">
 
                 <EditText
@@ -60,6 +57,228 @@
                     app:layout_constraintTop_toTopOf="parent"
                     tools:text="adfssfsfsasfsssssssssssssssssssssssssssssssssssssss" />
 
+                <ImageView
+                    android:id="@+id/iv_todo_edit_repeat"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/space_median"
+                    android:src="@drawable/ic_calendar"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_repeat_setting"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/tv_todo_edit_repeat_setting" />
+
+                <ImageView
+                    android:id="@+id/iv_todo_edit_time"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/space_median"
+                    android:src="@drawable/ic_time_filled"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_time_setting"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/tv_todo_edit_time_setting" />
+
+                <!-- 반복 설정 -->
+                <ImageView
+                    android:id="@+id/iv_todo_edit_keyword"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/space_median"
+                    android:src="@drawable/ic_visibility_outline"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_keyword_setting"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/tv_todo_edit_keyword_setting" />
+
+                <TextView
+                    android:id="@+id/tv_todo_edit_repeat_setting"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/space_x_small"
+                    android:layout_marginTop="@dimen/space_x_x_large"
+                    android:text="@string/todo_edit_repeat_setting"
+                    android:textColor="@color/black"
+                    android:textSize="@dimen/text_x_small"
+                    android:textStyle="bold"
+                    app:layout_constraintStart_toEndOf="@id/iv_todo_edit_repeat"
+                    app:layout_constraintTop_toBottomOf="@id/btn_todo_edit_label" />
+
+                <TextView
+                    android:id="@+id/tv_todo_edit_repeat_type"
+                    android:layout_marginTop="@dimen/space_small"
+                    android:text="@string/todo_edit_repeat_type"
+                    app:layout_constraintStart_toStartOf="@id/tv_todo_edit_repeat_setting"
+                    app:layout_constraintTop_toBottomOf="@id/tv_todo_edit_repeat_setting"
+                    style="@style/text_edit_todo_field" />
+
+                <TextView
+                    android:id="@+id/tv_todo_edit_repeat_type_value"
+                    style="@style/text_edit_todo_field"
+                    android:layout_marginEnd="@dimen/space_median"
+                    android:enabled="@{viewmodel.isRepeatChecked ? true : false}"
+                    android:onClick="@{()->viewmodel.onRepeatTypeClick()}"
+                    android:text="@{viewmodel.repeatType.text}"
+                    android:textColor="@{viewmodel.isRepeatChecked ? @color/black : @color/gray_normal}"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_repeat_type"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/tv_todo_edit_repeat_type"
+                    tools:text="매년" />
+
+                <TextView
+                    android:id="@+id/tv_todo_edit_repeat_start"
+                    android:text="@string/todo_edit_repeat_start"
+                    app:layout_constraintStart_toStartOf="@id/tv_todo_edit_repeat_setting"
+                    app:layout_constraintTop_toBottomOf="@id/tv_todo_edit_repeat_type"
+                    style="@style/text_edit_todo_field" />
+
+                <TextView
+                    android:id="@+id/tv_todo_edit_repeat_start_value"
+                    style="@style/text_edit_todo_field"
+                    android:layout_marginEnd="@dimen/space_median"
+                    android:enabled="@{viewmodel.isRepeatChecked ? true : false}"
+                    android:onClick="@{()->viewmodel.onRepeatStartClick()}"
+                    android:text="@{viewmodel.repeatStart}"
+                    android:textColor="@{viewmodel.isRepeatChecked ? @color/black : @color/gray_normal}"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_repeat_start"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/tv_todo_edit_repeat_start"
+                    tools:text="2021년 4월 15일" />
+
+                <TextView
+                    android:id="@+id/tv_todo_edit_time_setting"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/space_x_small"
+                    android:layout_marginTop="@dimen/space_median"
+                    android:text="@string/todo_edit_time_setting"
+                    android:textColor="@color/black"
+                    android:textSize="@dimen/text_x_small"
+                    android:textStyle="bold"
+                    app:layout_constraintStart_toEndOf="@id/iv_todo_edit_time"
+                    app:layout_constraintTop_toBottomOf="@id/divider_todo_edit_repeat" />
+
+                <TextView
+                    android:id="@+id/tv_todo_edit_time_start"
+                    android:layout_marginTop="@dimen/space_small"
+                    android:text="@string/todo_edit_time_start"
+                    app:layout_constraintStart_toStartOf="@id/tv_todo_edit_time_setting"
+                    app:layout_constraintTop_toBottomOf="@id/tv_todo_edit_time_setting"
+                    style="@style/text_edit_todo_field" />
+
+                <!-- 시간 설정 -->
+                <TextView
+                    android:id="@+id/tv_todo_edit_time_start_value"
+                    style="@style/text_edit_todo_field"
+                    android:layout_marginEnd="@dimen/space_median"
+                    android:enabled="@{viewmodel.isTimeChecked ? true : false}"
+                    android:onClick="@{()->viewmodel.onTimeStartClick()}"
+                    android:text="@{viewmodel.timeStart}"
+                    android:textColor="@{viewmodel.isTimeChecked ? @color/black : @color/gray_normal}"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_time_start"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/tv_todo_edit_time_start"
+                    tools:text="오전 08:00" />
+
+                <TextView
+                    android:id="@+id/tv_todo_edit_time_finish"
+                    android:text="@string/todo_edit_time_finish"
+                    app:layout_constraintStart_toStartOf="@id/tv_todo_edit_time_setting"
+                    app:layout_constraintTop_toBottomOf="@id/tv_todo_edit_time_start"
+                    style="@style/text_edit_todo_field" />
+
+                <TextView
+                    android:id="@+id/tv_todo_edit_time_finish_value"
+                    style="@style/text_edit_todo_field"
+                    android:layout_marginEnd="@dimen/space_median"
+                    android:enabled="@{viewmodel.isTimeChecked ? true : false}"
+                    android:onClick="@{()->viewmodel.onTimeFinishClick()}"
+                    android:text="@{viewmodel.timeFinish}"
+                    android:textColor="@{viewmodel.isTimeChecked ? @color/black : @color/gray_normal}"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_time_finish"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/tv_todo_edit_time_finish"
+                    tools:text="오후 02:00" />
+
+                <TextView
+                    android:id="@+id/tv_todo_edit_time_repeat"
+                    android:text="@string/todo_edit_time_repeat"
+                    app:layout_constraintStart_toStartOf="@id/tv_todo_edit_time_setting"
+                    app:layout_constraintTop_toBottomOf="@id/tv_todo_edit_time_finish"
+                    style="@style/text_edit_todo_field" />
+
+                <TextView
+                    android:id="@+id/tv_todo_edit_time_repeat_value"
+                    style="@style/text_edit_todo_field"
+                    android:layout_marginEnd="@dimen/space_median"
+                    android:enabled="@{viewmodel.isTimeChecked ? true : false}"
+                    android:onClick="@{()->viewmodel.onTimeRepeatClick()}"
+                    android:text="@{viewmodel.timeRepeat.text}"
+                    android:textColor="@{viewmodel.isTimeChecked ? @color/black : @color/gray_normal}"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_time_repeat"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/tv_todo_edit_time_repeat"
+                    tools:text="1시간" />
+
+                <TextView
+                    android:id="@+id/tv_todo_edit_keyword_setting"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/space_x_small"
+                    android:layout_marginTop="@dimen/space_median"
+                    android:text="@string/todo_edit_keyword_setting"
+                    android:textColor="@color/black"
+                    android:textSize="@dimen/text_x_small"
+                    android:textStyle="bold"
+                    app:layout_constraintStart_toEndOf="@id/iv_todo_edit_keyword"
+                    app:layout_constraintTop_toBottomOf="@id/divider_todo_edit_time" />
+
+                <View
+                    android:id="@+id/divider_todo_edit_repeat"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginHorizontal="@dimen/space_median"
+                    android:layout_marginTop="@dimen/space_x_small"
+                    android:background="@color/gray_light"
+                    app:layout_constraintTop_toBottomOf="@id/tv_todo_edit_repeat_start" />
+
+                <View
+                    android:id="@+id/divider_todo_edit_time"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginHorizontal="@dimen/space_median"
+                    android:layout_marginTop="@dimen/space_x_small"
+                    android:background="@color/gray_light"
+                    app:layout_constraintTop_toBottomOf="@id/tv_todo_edit_time_repeat" />
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/btn_todo_edit_save"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/todo_edit_button_margin"
+                    android:layout_marginEnd="@dimen/space_median"
+                    android:layout_marginBottom="@dimen/space_x_large"
+                    android:background="@drawable/bg_todo_edit_button"
+                    android:onClick="@{() -> viewmodel.saveTodo()}"
+                    android:text="@string/all_save"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/text_small"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_todo_edit_keyword_setting" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rv_todo_edit"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/space_median"
+                    android:layout_marginEnd="@dimen/space_median"
+                    android:orientation="horizontal"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                    app:layout_constraintBottom_toBottomOf="@+id/btn_todo_edit_label"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@+id/btn_todo_edit_label"
+                    app:layout_constraintTop_toTopOf="@+id/btn_todo_edit_label"
+                    tools:listitem="@layout/item_edit_todo_label" />
+
+                <!-- 키워드 공개 설정 -->
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/btn_todo_edit_label"
                     android:layout_width="@dimen/todo_edit_btn_size"
@@ -80,50 +299,12 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/et_todo_edit" />
 
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/rv_todo_edit"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/space_median"
-                    android:layout_marginEnd="@dimen/space_median"
-                    android:orientation="horizontal"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                    app:layout_constraintBottom_toBottomOf="@+id/btn_todo_edit_label"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@+id/btn_todo_edit_label"
-                    app:layout_constraintTop_toTopOf="@+id/btn_todo_edit_label"
-                    tools:listitem="@layout/item_edit_todo_label" />
-
-                <!-- 반복 설정 -->
-                <ImageView
-                    android:id="@+id/iv_todo_edit_repeat"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/space_median"
-                    android:src="@drawable/ic_calendar"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_repeat_setting"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@id/tv_todo_edit_repeat_setting" />
-
-                <TextView
-                    android:id="@+id/tv_todo_edit_repeat_setting"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/space_x_small"
-                    android:layout_marginTop="@dimen/space_x_x_large"
-                    android:text="@string/todo_edit_repeat_setting"
-                    android:textColor="@color/black"
-                    android:textSize="@dimen/text_x_small"
-                    android:textStyle="bold"
-                    app:layout_constraintStart_toEndOf="@id/iv_todo_edit_repeat"
-                    app:layout_constraintTop_toBottomOf="@id/btn_todo_edit_label" />
-
                 <com.google.android.material.switchmaterial.SwitchMaterial
                     android:id="@+id/switch_todo_edit_repeat"
                     style="@style/Widget.App.Switch"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginEnd="@dimen/space_median"
+                    android:layout_marginEnd="@dimen/space_x_small"
                     android:checked="@{viewmodel.isRepeatChecked}"
                     android:onCheckedChanged="@{(view, isChecked) -> viewmodel.updateIsRepeatChecked(isChecked)}"
                     app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_repeat_setting"
@@ -132,87 +313,12 @@
                     app:switchMinWidth="55dp"
                     tools:checked="false" />
 
-                <TextView
-                    android:id="@+id/tv_todo_edit_repeat_type"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/space_large"
-                    android:text="@string/todo_edit_repeat_type"
-                    app:layout_constraintStart_toStartOf="@id/tv_todo_edit_repeat_setting"
-                    app:layout_constraintTop_toBottomOf="@id/tv_todo_edit_repeat_setting" />
-
-                <TextView
-                    android:id="@+id/tv_todo_edit_repeat_type_value"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:enabled="@{viewmodel.isRepeatChecked ? true : false}"
-                    android:onClick="@{()->viewmodel.onRepeatTypeClick()}"
-                    android:text="@{viewmodel.repeatType.text}"
-                    android:textColor="@{viewmodel.isRepeatChecked ? @color/black : @color/gray_normal}"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_repeat_type"
-                    app:layout_constraintEnd_toEndOf="@id/switch_todo_edit_repeat"
-                    app:layout_constraintTop_toTopOf="@id/tv_todo_edit_repeat_type" />
-
-                <TextView
-                    android:id="@+id/tv_todo_edit_repeat_start"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/space_x_small"
-                    android:text="@string/todo_edit_repeat_start"
-                    app:layout_constraintStart_toStartOf="@id/tv_todo_edit_repeat_setting"
-                    app:layout_constraintTop_toBottomOf="@id/tv_todo_edit_repeat_type" />
-
-                <TextView
-                    android:id="@+id/tv_todo_edit_repeat_start_value"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:enabled="@{viewmodel.isRepeatChecked ? true : false}"
-                    android:onClick="@{()->viewmodel.onRepeatStartClick()}"
-                    android:text="@{viewmodel.repeatStart}"
-                    android:textColor="@{viewmodel.isRepeatChecked ? @color/black : @color/gray_normal}"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_repeat_start"
-                    app:layout_constraintEnd_toEndOf="@id/switch_todo_edit_repeat"
-                    app:layout_constraintTop_toTopOf="@id/tv_todo_edit_repeat_start" />
-
-                <View
-                    android:id="@+id/divider_todo_edit_repeat"
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:layout_marginHorizontal="@dimen/space_median"
-                    android:layout_marginTop="@dimen/space_median"
-                    android:background="@color/gray_light"
-                    app:layout_constraintTop_toBottomOf="@id/tv_todo_edit_repeat_start" />
-
-                <!-- 시간 설정 -->
-                <ImageView
-                    android:id="@+id/iv_todo_edit_time"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/space_median"
-                    android:src="@drawable/ic_time_filled"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_time_setting"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@id/tv_todo_edit_time_setting" />
-
-                <TextView
-                    android:id="@+id/tv_todo_edit_time_setting"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/space_x_small"
-                    android:layout_marginTop="@dimen/space_median"
-                    android:text="@string/todo_edit_time_setting"
-                    android:textColor="@color/black"
-                    android:textSize="@dimen/text_x_small"
-                    android:textStyle="bold"
-                    app:layout_constraintStart_toEndOf="@id/iv_todo_edit_time"
-                    app:layout_constraintTop_toBottomOf="@id/divider_todo_edit_repeat" />
-
                 <com.google.android.material.switchmaterial.SwitchMaterial
                     android:id="@+id/switch_todo_edit_time"
                     style="@style/Widget.App.Switch"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginEnd="@dimen/space_median"
+                    android:layout_marginEnd="@dimen/space_x_small"
                     android:checked="@{viewmodel.isTimeChecked}"
                     android:onCheckedChanged="@{(view, isChecked) -> viewmodel.updateIsTimeChecked(isChecked)}"
                     app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_time_setting"
@@ -221,108 +327,12 @@
                     app:switchMinWidth="55dp"
                     tools:checked="false" />
 
-                <TextView
-                    android:id="@+id/tv_todo_edit_time_start"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/space_large"
-                    android:text="@string/todo_edit_time_start"
-                    app:layout_constraintStart_toStartOf="@id/tv_todo_edit_time_setting"
-                    app:layout_constraintTop_toBottomOf="@id/tv_todo_edit_time_setting" />
-
-                <TextView
-                    android:id="@+id/tv_todo_edit_time_start_value"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:enabled="@{viewmodel.isTimeChecked ? true : false}"
-                    android:onClick="@{()->viewmodel.onTimeStartClick()}"
-                    android:text="@{viewmodel.timeStart}"
-                    android:textColor="@{viewmodel.isTimeChecked ? @color/black : @color/gray_normal}"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_time_start"
-                    app:layout_constraintEnd_toEndOf="@id/switch_todo_edit_time"
-                    app:layout_constraintTop_toTopOf="@id/tv_todo_edit_time_start" />
-
-                <TextView
-                    android:id="@+id/tv_todo_edit_time_finish"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/space_x_small"
-                    android:text="@string/todo_edit_time_finish"
-                    app:layout_constraintStart_toStartOf="@id/tv_todo_edit_time_setting"
-                    app:layout_constraintTop_toBottomOf="@id/tv_todo_edit_time_start" />
-
-                <TextView
-                    android:id="@+id/tv_todo_edit_time_finish_value"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:enabled="@{viewmodel.isTimeChecked ? true : false}"
-                    android:onClick="@{()->viewmodel.onTimeFinishClick()}"
-                    android:text="@{viewmodel.timeFinish}"
-                    android:textColor="@{viewmodel.isTimeChecked ? @color/black : @color/gray_normal}"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_time_finish"
-                    app:layout_constraintEnd_toEndOf="@id/switch_todo_edit_time"
-                    app:layout_constraintTop_toTopOf="@id/tv_todo_edit_time_finish" />
-
-                <TextView
-                    android:id="@+id/tv_todo_edit_time_repeat"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/space_x_small"
-                    android:text="@string/todo_edit_time_repeat"
-                    app:layout_constraintStart_toStartOf="@id/tv_todo_edit_time_setting"
-                    app:layout_constraintTop_toBottomOf="@id/tv_todo_edit_time_finish" />
-
-                <TextView
-                    android:id="@+id/tv_todo_edit_time_repeat_value"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:enabled="@{viewmodel.isTimeChecked ? true : false}"
-                    android:onClick="@{()->viewmodel.onTimeRepeatClick()}"
-                    android:text="@{viewmodel.timeRepeat.text}"
-                    android:textColor="@{viewmodel.isTimeChecked ? @color/black : @color/gray_normal}"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_time_repeat"
-                    app:layout_constraintEnd_toEndOf="@id/switch_todo_edit_time"
-                    app:layout_constraintTop_toTopOf="@id/tv_todo_edit_time_repeat" />
-
-                <View
-                    android:id="@+id/divider_todo_edit_time"
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:layout_marginHorizontal="@dimen/space_median"
-                    android:layout_marginTop="@dimen/space_median"
-                    android:background="@color/gray_light"
-                    app:layout_constraintTop_toBottomOf="@id/tv_todo_edit_time_repeat" />
-
-                <!-- 키워드 공개 설정 -->
-                <ImageView
-                    android:id="@+id/iv_todo_edit_keyword"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/space_median"
-                    android:src="@drawable/ic_visibility_outline"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_keyword_setting"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@id/tv_todo_edit_keyword_setting" />
-
-                <TextView
-                    android:id="@+id/tv_todo_edit_keyword_setting"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/space_x_small"
-                    android:layout_marginTop="@dimen/space_median"
-                    android:text="@string/todo_edit_keyword_setting"
-                    android:textColor="@color/black"
-                    android:textSize="@dimen/text_x_small"
-                    android:textStyle="bold"
-                    app:layout_constraintStart_toEndOf="@id/iv_todo_edit_keyword"
-                    app:layout_constraintTop_toBottomOf="@id/divider_todo_edit_time" />
-
                 <com.google.android.material.switchmaterial.SwitchMaterial
                     android:id="@+id/switch_todo_edit_keyword"
                     style="@style/Widget.App.Switch"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginEnd="@dimen/space_median"
+                    android:layout_marginEnd="@dimen/space_x_small"
                     android:checked="@{viewmodel.isKeywordChecked}"
                     android:onCheckedChanged="@{(view, isChecked) -> viewmodel.updateIsKeywordChecked(isChecked)}"
                     app:layout_constraintBottom_toBottomOf="@id/tv_todo_edit_keyword_setting"
@@ -331,26 +341,9 @@
                     app:switchMinWidth="55dp"
                     tools:checked="false" />
 
-                <androidx.appcompat.widget.AppCompatButton
-                    android:id="@+id/btn_todo_edit_save"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/todo_edit_button_margin"
-                    android:layout_marginEnd="@dimen/space_median"
-                    android:layout_marginBottom="@dimen/space_x_large"
-                    android:background="@drawable/bg_todo_edit_button"
-                    android:onClick="@{() -> viewmodel.saveTodo()}"
-                    android:text="@string/all_save"
-                    android:textColor="@color/white"
-                    android:textSize="@dimen/text_small"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_todo_edit_keyword_setting" />
-
             </androidx.constraintlayout.widget.ConstraintLayout>
 
-        </androidx.core.widget.NestedScrollView>
+        </ScrollView>
 
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
-
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_edit_todo_label.xml
+++ b/app/src/main/res/layout/item_edit_todo_label.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="item"
+            type="com.gojol.notto.model.database.label.Label" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/chip_home_label"
+            style="@style/Widget.MaterialComponents.Chip.Choice"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="2dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:text="@{item.name}"
+            android:textColor="@color/black"
+            android:textSize="@dimen/text_x_x_small"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:closeIcon="@drawable/ic_cancel"
+            app:closeIconVisible="true"
+            app:closeIconTint="@color/gray_normal"
+            app:chipStrokeWidth="1dp"
+            app:chipStrokeColor="@color/gray_normal"
+            app:chipBackgroundColor="@color/white"
+            tools:text="@string/home_label_all" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -27,4 +27,12 @@
         <item name="android:paddingBottom">@dimen/space_median</item>
         <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
     </style>
+
+    <style name="text_edit_todo_field">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:paddingTop">@dimen/space_x_small</item>
+        <item name="android:paddingBottom">@dimen/space_x_small</item>
+        <item name="android:textColor">@color/charcoal_normal</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -44,5 +44,6 @@
         <item name="android:elevation">0dp</item>
         <item name="android:background">@color/white</item>
         <item name="titleTextColor">@color/black</item>
+        <item name="titleCentered">true</item>
     </style>
 </resources>


### PR DESCRIPTION
# 기능 구현 내용
- [x] 투두 편집 화면 라벨 아이템에 closeIcon 추가
- [x] 투두 편집 화면 라벨 아이템 background 변경
- [x] CoordinateLayout & NestedScrollView를 ConstraintLayout & ScrollView로 변경
- [x] Toolbar 통일
- [x] 텍스트 터치 영역 확장

# 기능 구현 결과

<img width=300 src=https://user-images.githubusercontent.com/39328846/142378475-0ba68b1c-8363-4262-bf20-532bb7352ae2.jpg>
