### PR TITLE
[develop] Todo 편집 화면 기능 추가

### DIFF
--- a/app/src/main/java/com/gojol/notto/model/data/todo/ClickWrapper.kt
+++ b/app/src/main/java/com/gojol/notto/model/data/todo/ClickWrapper.kt
@@ -5,6 +5,7 @@ import com.gojol.notto.common.Event
 
 data class ClickWrapper(
     val isTodoEditing: MutableLiveData<Boolean>,
+    val isBeforeToday: MutableLiveData<Boolean>,
     val isCloseButtonCLicked: MutableLiveData<Event<Unit>>,
     val popLabelAddDialog: MutableLiveData<Boolean>,
     val labelAddClicked: MutableLiveData<Event<Unit>>,

--- a/app/src/main/java/com/gojol/notto/model/data/todo/ClickWrapper.kt
+++ b/app/src/main/java/com/gojol/notto/model/data/todo/ClickWrapper.kt
@@ -13,6 +13,7 @@ data class ClickWrapper(
     val timeStartClick: MutableLiveData<Event<Boolean>>,
     val timeFinishClick: MutableLiveData<Event<Boolean>>,
     val timeRepeatClick: MutableLiveData<Event<Boolean>>,
+    val deleteButtonClick: MutableLiveData<Event<Unit>>,
     val isDeletionExecuted: MutableLiveData<Event<Unit>>,
     val isSaveButtonEnabled: MutableLiveData<Boolean>,
     val isSaveButtonClicked: MutableLiveData<Pair<Boolean, Boolean>>

--- a/app/src/main/java/com/gojol/notto/model/database/todolabel/TodoLabelDao.kt
+++ b/app/src/main/java/com/gojol/notto/model/database/todolabel/TodoLabelDao.kt
@@ -67,6 +67,9 @@ interface TodoLabelDao {
     @Update
     suspend fun updateTodo(todo: Todo)
 
+    @Query("UPDATE Todo SET finish_date=:finishDate, is_finished=:isFinished WHERE todoId=:todoId")
+    suspend fun updateTodoFinishDate(todoId: Int, isFinished: Boolean, finishDate: LocalDate)
+
     @Update
     suspend fun updateLabel(label: Label)
 

--- a/app/src/main/java/com/gojol/notto/ui/todo/TodoEditActivity.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/TodoEditActivity.kt
@@ -107,6 +107,7 @@ class TodoEditActivity : AppCompatActivity() {
     }
 
     private fun setRecyclerViewCallback(label: Label) {
+        if (todoEditViewModel.clickWrapper.isBeforeToday.value == true) return
         todoEditViewModel.removeLabelFromSelectedLabelList(label)
     }
 
@@ -119,6 +120,12 @@ class TodoEditActivity : AppCompatActivity() {
                 binding.btnTodoEditDelete.visibility = View.GONE
             }
         }
+        todoEditViewModel.clickWrapper.isBeforeToday.observe(this, {
+            if (it) { //편집일 때
+                binding.tbTodoEdit.title = getString(R.string.todo_edit_title_detail)
+                blockClick()
+            } else showBeforeTodayDisabled()
+        })
         todoEditViewModel.clickWrapper.isCloseButtonCLicked.observe(this, EventObserver {
             finish()
         })
@@ -260,6 +267,10 @@ class TodoEditActivity : AppCompatActivity() {
         ).show()
     }
 
+    private fun showBeforeTodayDisabled() {
+        Toast.makeText(this, getString(R.string.todo_edit_before_today_msg), Toast.LENGTH_LONG).show()
+    }
+
     private fun onLabelAddClick() {
         val fragmentManager = this.supportFragmentManager
         val dialog = EditLabelDialogBuilder.builder(LabelEditType.CREATE, null).apply {
@@ -273,6 +284,23 @@ class TodoEditActivity : AppCompatActivity() {
                 todoEditViewModel.initLabelData()
                 dialog.dismiss()
             }
+        }
+    }
+
+    private fun blockClick() {
+        with(binding) {
+            etTodoEdit.isEnabled = false
+            btnTodoEditLabel.isClickable = false
+            rvTodoEdit.isClickable = false
+            tvTodoEditRepeatStartValue.isClickable = false
+            tvTodoEditRepeatTypeValue.isClickable = false
+            tvTodoEditTimeStartValue.isClickable = false
+            tvTodoEditTimeFinishValue.isClickable = false
+            tvTodoEditTimeRepeatValue.isClickable = false
+            switchTodoEditRepeat.isEnabled = false
+            switchTodoEditTime.isEnabled = false
+            switchTodoEditKeyword.isEnabled = false
+            btnTodoEditSave.visibility = View.GONE
         }
     }
 }

--- a/app/src/main/java/com/gojol/notto/ui/todo/TodoEditActivity.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/TodoEditActivity.kt
@@ -1,5 +1,6 @@
 package com.gojol.notto.ui.todo
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.MotionEvent
 import android.view.View
@@ -13,6 +14,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.databinding.DataBindingUtil
 import com.gojol.notto.R
+import com.gojol.notto.common.DELETE
 import com.gojol.notto.common.EventObserver
 import com.gojol.notto.common.LABEL_ADD
 import com.gojol.notto.common.LabelEditType
@@ -114,11 +116,14 @@ class TodoEditActivity : AppCompatActivity() {
                 todoEditViewModel.setupExistedTodo()
                 binding.tbTodoEdit.title = getString(R.string.todo_edit_title_edit)
             } else {
-                binding.btnTodoEditDelete.visibility = View.INVISIBLE
+                binding.btnTodoEditDelete.visibility = View.GONE
             }
         }
         todoEditViewModel.clickWrapper.isCloseButtonCLicked.observe(this, EventObserver {
             finish()
+        })
+        todoEditViewModel.clickWrapper.deleteButtonClick.observe(this, EventObserver {
+            todoDeletionDialog.show(supportFragmentManager, DELETE)
         })
         todoEditViewModel.clickWrapper.isDeletionExecuted.observe(this, EventObserver {
             finish()
@@ -220,6 +225,7 @@ class TodoEditActivity : AppCompatActivity() {
         )
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     private fun initEditTextTouchListener() {
         binding.etTodoEdit.setOnTouchListener { view, motionEvent ->
             if (view == binding.etTodoEdit) {

--- a/app/src/main/java/com/gojol/notto/ui/todo/TodoEditViewModel.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/TodoEditViewModel.kt
@@ -41,7 +41,7 @@ class TodoEditViewModel @Inject constructor(
     val clickWrapper = ClickWrapper(
         MutableLiveData(), MutableLiveData(), MutableLiveData(), MutableLiveData(), MutableLiveData(),
         MutableLiveData(), MutableLiveData(), MutableLiveData(), MutableLiveData(), MutableLiveData(),
-        MutableLiveData(), MutableLiveData()
+        MutableLiveData(), MutableLiveData(), MutableLiveData()
     )
 
     private val firebaseDB = FirebaseDB(BuildConfig.FIREBASE_DB_URL)
@@ -168,6 +168,10 @@ class TodoEditViewModel @Inject constructor(
 
     fun onIsCloseButtonClicked() {
         clickWrapper.isCloseButtonCLicked.value = Event(Unit)
+    }
+
+    fun onDeleteButtonCLick(){
+        clickWrapper.deleteButtonClick.value = Event(Unit)
     }
 
     fun onRepeatTypeClick() {

--- a/app/src/main/java/com/gojol/notto/ui/todo/TodoEditViewModel.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/TodoEditViewModel.kt
@@ -41,7 +41,7 @@ class TodoEditViewModel @Inject constructor(
     val clickWrapper = ClickWrapper(
         MutableLiveData(), MutableLiveData(), MutableLiveData(), MutableLiveData(), MutableLiveData(),
         MutableLiveData(), MutableLiveData(), MutableLiveData(), MutableLiveData(), MutableLiveData(),
-        MutableLiveData(), MutableLiveData(), MutableLiveData()
+        MutableLiveData(), MutableLiveData(), MutableLiveData(), MutableLiveData()
     )
 
     private val firebaseDB = FirebaseDB(BuildConfig.FIREBASE_DB_URL)
@@ -121,7 +121,20 @@ class TodoEditViewModel @Inject constructor(
     }
 
     fun updateDate(date: LocalDate?) {
-        val selectedDate = date ?: return
+        val isEditing = clickWrapper.isTodoEditing.value ?: return
+        var selectedDate = date ?: return
+
+        if (isEditing) {
+            if (selectedDate.isBefore(LocalDate.now())) {
+                clickWrapper.isBeforeToday.value = isEditing
+            }
+        } else {
+            if (selectedDate.isBefore(LocalDate.now())) {
+                selectedDate = LocalDate.now()
+                clickWrapper.isBeforeToday.value = isEditing
+            }
+        }
+
         _todoWrapper.value = todoWrapper.value?.copy(selectedDate = selectedDate)
     }
 

--- a/app/src/main/java/com/gojol/notto/ui/todo/dialog/RepeatTimeDialog.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/dialog/RepeatTimeDialog.kt
@@ -25,6 +25,11 @@ class RepeatTimeDialog : BaseDialog<DialogTodoRepeatTimeBinding, RepeatTimeDialo
         super.onViewCreated(view, savedInstanceState)
         binding.viewmodel = viewModel
         repeatTimeCallback?.let { viewModel.setRepeatTimeCallback(it) }
+
+        binding.cvRepeatTime.state().edit().setMinimumDate(
+            Date.from(LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant())
+        ).commit()
+
         initObserver()
         initRepeatTime()
         initClickListener()

--- a/app/src/main/res/layout/activity_todo_edit.xml
+++ b/app/src/main/res/layout/activity_todo_edit.xml
@@ -50,6 +50,7 @@
             app:layout_constraintTop_toBottomOf="@+id/tb_todo_edit">
 
             <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_todo_edit"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 tools:context=".ui.todo.TodoEditActivity">

--- a/app/src/main/res/layout/activity_todo_edit.xml
+++ b/app/src/main/res/layout/activity_todo_edit.xml
@@ -36,6 +36,7 @@
             android:layout_marginEnd="@dimen/space_median"
             android:background="@android:color/transparent"
             android:src="@drawable/ic_delete"
+            android:onClick="@{() -> viewmodel.onDeleteButtonCLick()}"
             app:layout_constraintBottom_toBottomOf="@id/tb_todo_edit"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/tb_todo_edit" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="todo_edit_keyword_setting">키워드 공개 여부 설정</string>
     <string name="todo_edit_title_create">Not Todo 생성</string>
     <string name="todo_edit_title_edit">Not Todo 편집</string>
+    <string name="todo_edit_title_detail">Not Todo 상세</string>
     <string name="todo_edit_edit_text_hint">Not Todo를 입력하세요</string>
     <string name="todo_edit_label_select">라벨 선택</string>
     <string name="todo_edit_label_select_sentence">라벨을 선택하세요</string>
@@ -39,6 +40,7 @@
     <string name="todo_edit_delete_message">Not Todo가 삭제되었습니다.</string>
     <string name="todo_edit_save_button_title">Not Todo 업데이트</string>
     <string name="todo_edit_save_button_msg">업데이트하면 이전에 작성한 Not Todo가 변경될 수 있습니다.</string>
+    <string name="todo_edit_before_today_msg">이전 날짜로는 Not Todo를 생성할 수 없어 오늘 날짜로 생성합니다.</string>
 
     <string name="dialog_deletion_title">Not Todo 삭제하기</string>
     <string name="dialog_deletion_description">삭제하면 다시 복구할 수 없습니다. \n정말 삭제하시겠습니까?</string>


### PR DESCRIPTION
# 기능 구현 내용
- [x] 편집화면의 반복 시작일 다이얼로그를 오늘 날짜부터 선택 가능하도록 수정
- [x] 투두 생성, 업데이트, 삭제 로직 수정
- [x] 캘린더에서 오늘보다 이전 날짜를 선택한 경우
  - [x] 편집 버튼을 눌렀을 때 상세화면으로
  - [x] 생성 버튼을 눌렀을 때 선택된 날짜를 오늘로 변경 

# 기능 구현 결과

https://user-images.githubusercontent.com/55148494/143433617-2f98d9ad-b38d-4726-94a6-316c0d041d10.mp4

열심히 터치하고 있는데 화면상으로는 안보이네요..ㅜㅜ 터치 안먹습니다!

# Resolve
- #13
