### PR TITLE
[develop] 라벨 수정 다이얼로그 버그 해결

### DIFF
--- a/app/src/main/java/com/gojol/notto/ui/label/dialog/edit/EditLabelDialogViewModel.kt
+++ b/app/src/main/java/com/gojol/notto/ui/label/dialog/edit/EditLabelDialogViewModel.kt
@@ -25,7 +25,9 @@ class EditLabelDialogViewModel @Inject constructor(private val repository: TodoL
     val name = MutableLiveData<String>()
 
     fun clickOkay() {
-        val labelName = name.value ?: return
+        val labelName = name.value?.apply {
+            if (isBlank()) return
+        } ?: return
 
         viewModelScope.launch {
             when (type.value) {


### PR DESCRIPTION
# 기능 구현 내용
- [x] 라벨 수정 다이얼로그에서 빈칸인 경우 무시하도록 처리
