### PR TITLE
[develop] 다크모드 캘린더 달성률 색 변경 및 캘린더 월별 데이터 로직 수정

### DIFF
--- a/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarDayAdapter.kt
+++ b/app/src/main/java/com/gojol/notto/ui/home/adapter/CalendarDayAdapter.kt
@@ -52,6 +52,7 @@ class CalendarDayAdapter(private val dayClickCallback: (Int) -> (Unit)) :
                     dayClickCallback(binding.tvCalendarDay.text.toString().toInt())
                 }
             } else {
+                binding.ivSuccessLevelBackground.visibility = View.INVISIBLE
                 binding.ivSuccessLevel.visibility = View.INVISIBLE
             }
 
@@ -78,7 +79,10 @@ class CalendarDayAdapter(private val dayClickCallback: (Int) -> (Unit)) :
 
         private fun setSuccessLevel(achievement: Int) {
             binding.ivSuccessLevel.backgroundTintList = if (achievement == 0) {
-                ContextCompat.getColorStateList(binding.root.context, R.color.gray_light)
+                ContextCompat.getColorStateList(
+                    binding.root.context,
+                    R.color.calendar_day_background_default
+                )
             } else {
                 ContextCompat.getColorStateList(binding.root.context, R.color.yellow_deep)
                     ?.withAlpha(achievement)

--- a/app/src/main/res/layout/item_calendar_day.xml
+++ b/app/src/main/res/layout/item_calendar_day.xml
@@ -16,6 +16,7 @@
         android:layout_marginVertical="4dp">
 
         <ImageView
+            android:id="@+id/iv_successLevel_background"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:background="@drawable/bg_calendar_day_circle"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -7,4 +7,5 @@
     <color name="calendar_day_default">@color/gray_normal</color>
 
     <color name="calendar_today_button">@color/white</color>
+    <color name="calendar_day_background_default">@color/gray_normal</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -25,4 +25,5 @@
     <color name="calendar_day_selected">@color/black</color>
     <color name="calendar_day_default">@color/gray_deep</color>
     <color name="calendar_today_button">@color/black</color>
+    <color name="calendar_day_background_default">@color/gray_light</color>
 </resources>


### PR DESCRIPTION
# 기능 구현 내용
- [x] 달성률 색을 gray normal로 수정하고 빈 날짜는 뒷 배경 색 invisible

# 기능 구현 결과
![image](https://user-images.githubusercontent.com/64943924/143462394-fbd83b00-fdf9-4646-92ce-81a95ab0479f.png)
