### PR TITLE
[develop] 라벨 선택 다이얼로그 회전 관련 버그 수정

### DIFF
--- a/app/src/main/java/com/gojol/notto/model/data/todo/ClickWrapper.kt
+++ b/app/src/main/java/com/gojol/notto/model/data/todo/ClickWrapper.kt
@@ -7,7 +7,7 @@ data class ClickWrapper(
     val isTodoEditing: MutableLiveData<Boolean>,
     val isBeforeToday: MutableLiveData<Boolean>,
     val isCloseButtonCLicked: MutableLiveData<Event<Unit>>,
-    val popLabelAddDialog: MutableLiveData<Boolean>,
+    val popLabelAddDialog: MutableLiveData<Event<Boolean>>,
     val labelAddClicked: MutableLiveData<Event<Unit>>,
     val repeatTypeClick: MutableLiveData<Event<Boolean>>,
     val repeatStartClick: MutableLiveData<Event<Boolean>>,

--- a/app/src/main/java/com/gojol/notto/ui/todo/TodoEditActivity.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/TodoEditActivity.kt
@@ -155,9 +155,9 @@ class TodoEditActivity : AppCompatActivity() {
             if (!it) showSaveButtonDisabled()
             else finish()
         }
-        todoEditViewModel.clickWrapper.popLabelAddDialog.observe(this) {
+        todoEditViewModel.clickWrapper.popLabelAddDialog.observe(this, EventObserver {
             if (it) showLabelAddDialog()
-        }
+        })
         todoEditViewModel.clickWrapper.labelAddClicked.observe(this, EventObserver {
             onLabelAddClick()
         })

--- a/app/src/main/java/com/gojol/notto/ui/todo/TodoEditViewModel.kt
+++ b/app/src/main/java/com/gojol/notto/ui/todo/TodoEditViewModel.kt
@@ -209,7 +209,7 @@ class TodoEditViewModel @Inject constructor(
     }
 
     fun onPopLabelAddDialogClick() {
-        clickWrapper.popLabelAddDialog.value = true
+        clickWrapper.popLabelAddDialog.value = Event(true)
     }
 
     private fun onLabelAddClick() {


### PR DESCRIPTION
# 기능 구현 내용
- [x] todo 편집 화면에서 회전할 때 label 추가 다이얼로그가 사라지지 않던 문제 수정  

# 기능 구현 결과
![KakaoTalk_Photo_2021-11-30-20-57-24](https://user-images.githubusercontent.com/26290540/144043257-0327d88d-73fb-46f4-9662-22dd42258d17.gif)


